### PR TITLE
Switch to AD4 minimum and maximum bond distances

### DIFF
--- a/common/defines.h
+++ b/common/defines.h
@@ -48,6 +48,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 	#define NUM_OF_THREADS_PER_BLOCK 16
 #endif
 
+enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.dat" or "AD4_parameters.dat" file.
+#define NUM_ENUM_ATOMTYPES 7 // this should be the length of the enumerated atom types above
+
 // Indexes of atomic types used in
 // host/src/processligand.cpp/get_VWpars(),
 // and kernel energy & gradient calculation.

--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -30,6 +30,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "processgrid.h"
 #include "miscellaneous.h"
 
+// expand the allowed bond length ranges by the BOND_LENGTH_TOLERANCE
+#define BOND_LENGTH_TOLERANCE 0.1
+#define set_minmax( a1, a2, min, max)  \
+    mindist[(a1)][(a2)] = (mindist[(a2)][(a1)] = (min)-BOND_LENGTH_TOLERANCE);\
+    maxdist[(a1)][(a2)] = (maxdist[(a2)][(a1)] = (max)+BOND_LENGTH_TOLERANCE)
+
 typedef struct
 //Struct which contains ligand information. The fields contain the following information:
 //num_of_atoms: 	Number of ligand atoms.

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -23,7 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 
-// Use AD4 minimum and maximum bond distances instead of the Frankenstein we had in AD-GPU
+// Use AD4 minimum and maximum bond distances (from AD4.2.6) as the ones
+// in AD-GPU (when this is commented out) currently are not complete
 #define AD4_BOND_DISTS
 
 // Output showing the CG-G0 virtual bonds and pairs

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -23,6 +23,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 
+// Use AD4 minimum and maximum bond distances instead of the Frankenstein we had in AD-GPU
+#define AD4_BOND_DISTS
+
 // Output showing the CG-G0 virtual bonds and pairs
 // #define CG_G0_INFO
 
@@ -412,8 +415,8 @@ int get_bonds(Liganddata* myligand)
 					     0  // "CX"
 					    };
 
-	double mindist[7][7];
-	double maxdist[7][7];
+	double mindist[NUM_ENUM_ATOMTYPES][NUM_ENUM_ATOMTYPES];
+	double maxdist[NUM_ENUM_ATOMTYPES][NUM_ENUM_ATOMTYPES];
 
 	double temp_point1 [3];
 	double temp_point2 [3];
@@ -448,6 +451,49 @@ int get_bonds(Liganddata* myligand)
 	strcpy(atom_names[18], "W"); // used to disable all bonds containing W
 	strcpy(atom_names[19], "CX"); // used to disable all bonds containing W
 
+#ifdef AD4_BOND_DISTS
+	// Set all the mindist and maxdist elements to the defaults for AutoDock versions 1 - 3...
+	for (i=0; i<   NUM_ENUM_ATOMTYPES; i++) {
+		for (j=0; j<   NUM_ENUM_ATOMTYPES; j++) {
+			mindist[i][j] = 0.9 - BOND_LENGTH_TOLERANCE;
+			maxdist[i][j] = 2.1 + BOND_LENGTH_TOLERANCE;
+		}
+	}
+	/*
+	 * These values, unless otherwise stated,
+	 * are taken from "handbook of Chemistry and Physics"
+	 * 44th edition(!)
+	 */
+	set_minmax(C, C, 1.20, 1.545); // mindist[C][C] = 1.20, p. 3510 ; maxdist[C][C] = 1.545, p. 3511
+	set_minmax(C, N, 1.1, 1.479); // mindist[C][N] = 1.1, p. 3510 ; maxdist[C][N] = 1.479, p. 3511
+	set_minmax(C, O, 1.15, 1.47); // mindist[C][O] = 1.15, p. 3510 ; maxdist[C][O] = 1.47, p. 3512
+	set_minmax(C, H, 1.022, 1.12);  // p. 3518, p. 3517
+	set_minmax(C, XX, 0.9, 1.545); // mindist[C][XX] = 0.9, AutoDock 3 defaults ; maxdist[C][XX] = 1.545, p. 3511
+	set_minmax(C, P, 1.85, 1.89); // mindist[C][P] = 1.85, p. 3510 ; maxdist[C][P] = 1.89, p. 3510
+	set_minmax(C, S, 1.55, 1.835); // mindist[C][S] = 1.55, p. 3510 ; maxdist[C][S] = 1.835, p. 3512
+	set_minmax(N, N, 1.0974, 1.128); // mindist[N][N] = 1.0974, p. 3513 ; maxdist[N][N] = 1.128, p. 3515
+	set_minmax(N, O, 1.0619, 1.25); // mindist[N][O] = 1.0975, p. 3515 ; maxdist[N][O] = 1.128, p. 3515
+	set_minmax(N, H, 1.004, 1.041); // mindist[N][H] = 1.004, p. 3516 ; maxdist[N][H] = 1.041, p. 3515
+	set_minmax(N, XX, 0.9, 1.041); // mindist[N][XX] = 0.9, AutoDock 3 defaults ; maxdist[N][XX] = 1.041, p. 3515
+	set_minmax(N, P, 1.4910, 1.4910); // mindist[N][P] = 1.4910, p. 3515 ; maxdist[N][P] = 1.4910, p. 3515
+	set_minmax(N, S, 1.58, 1.672); // mindist[N][S] = 1.58, 1czm.pdb sulfonamide ; maxdist[N][S] = 1.672, J. Chem. SOC., Dalton Trans., 1996, Pages 4063-4069 
+	set_minmax(O, O, 1.208, 1.51); // p.3513, p.3515
+	set_minmax(O, H, 0.955, 1.0289); // mindist[O][H] = 0.955, p. 3515 ; maxdist[O][H] = 1.0289, p. 3515
+	set_minmax(O, XX, 0.955, 2.1); // AutoDock 3 defaults
+	set_minmax(O, P, 1.36, 1.67); // mindist[O][P] = 1.36, p. 3516 ; maxdist[O][P] = 1.67, p. 3517
+	set_minmax(O, S, 1.41, 1.47); // p. 3517, p. 3515
+	set_minmax(H, H, 100.,-100.); // impossible values to prevent such bonds from forming.
+	set_minmax(H, XX, 0.9, 1.5); // AutoDock 4 defaults
+	set_minmax(H, P, 1.40, 1.44); // mindist[H][P] = 1.40, p. 3515 ; maxdist[H][P] = 1.44, p. 3515
+	set_minmax(H, S, 1.325, 1.3455); // mindist[H][S] = 1.325, p. 3518 ; maxdist[H][S] = 1.3455, p. 3516
+	set_minmax(XX, XX, 0.9, 2.1); // AutoDock 3 defaults
+	set_minmax(XX, P, 0.9, 2.1); // AutoDock 3 defaults
+	set_minmax(XX, S, 1.325, 2.1); // mindist[XX][S] = 1.325, p. 3518 ; maxdist[XX][S] = 2.1, AutoDock 3 defaults
+	set_minmax(P, P, 2.18, 2.23); // mindist[P][P] = 2.18, p. 3513 ; maxdist[P][P] = 2.23, p. 3513
+	set_minmax(P, S, 1.83, 1.88); // mindist[P][S] = 1.83, p. 3516 ; maxdist[P][S] = 1.88, p. 3515
+	set_minmax(S, S, 2.03, 2.05); // mindist[S][S] = 2.03, p. 3515 ; maxdist[S][S] = 2.05, p. 3515
+	/* end values from Handbook of Chemistry and Physics */
+#else
 	//Filling the mindist and maxdist tables (as in Autodock, see AD4_parameters.dat and mdist.h).
 	//It is supposed that the bond length of atoms with bondtype_id1 and bondtype_id2 is
 	//between mindist[bondtype_id1][bondtype_id2] and maxdist[bondtype_id1][bondtype_id2]
@@ -461,33 +507,34 @@ int get_bonds(Liganddata* myligand)
 	}
 
 	//0=C, 3=H
-	mindist[0][3] = 1.07; mindist[3][0] = mindist[0][3];
-	maxdist[0][3] = 1.15; maxdist[3][0] = maxdist[0][3];
+	mindist[C][H] = 1.07; mindist[H][C] = mindist[C][H];
+	maxdist[C][H] = 1.15; maxdist[H][C] = maxdist[C][H];
 
 	//1=N
-	mindist[1][3] = 0.99; mindist[3][1] = mindist[1][3];
-	maxdist[1][3] = 1.10; maxdist[3][1] = maxdist[1][3];
+	mindist[N][H] = 0.99; mindist[H][N] = mindist[N][H];
+	maxdist[N][H] = 1.10; maxdist[H][N] = maxdist[N][H];
 
 	//2=O
-	mindist[2][3] = 0.94; mindist[3][2] = mindist[2][3];
-	maxdist[2][3] = 1.10; maxdist[3][2] = maxdist[2][3];
+	mindist[O][H] = 0.94; mindist[H][O] = mindist[O][H];
+	maxdist[O][H] = 1.10; maxdist[H][O] = maxdist[O][H];
 
 	//6=S
-	mindist[6][3] = 1.316; mindist[3][6] = mindist[6][3];
-	maxdist[6][3] = 1.356; maxdist[3][6] = maxdist[6][3];
+	mindist[S][H] = 1.316; mindist[H][S] = mindist[S][H];
+	maxdist[S][H] = 1.356; maxdist[H][S] = maxdist[S][H];
 
 	//5=P
-	mindist[5][3] = 1.35; mindist[3][5] = mindist[5][3];
-	maxdist[5][3] = 1.40; maxdist[3][5] = maxdist[5][3];
+	mindist[P][H] = 1.35; mindist[H][P] = mindist[P][H];
+	maxdist[P][H] = 1.40; maxdist[H][P] = maxdist[P][H];
 
-	mindist[1][2] = 1.11;  // N=O is ~ 1.21 A, minus 0.1A error
-	maxdist[1][2] = 1.50;  // N-O is ~ 1.40 A, plus 0.1 A error
-	mindist[2][1] = mindist[1][2];  // N=O is ~ 1.21 A, minus 0.1A error
-	maxdist[2][1] = maxdist[1][2];  // N-O is ~ 1.40 A, plus 0.1 A error
+	mindist[N][O] = 1.11;  // N=O is ~ 1.21 A, minus 0.1A error
+	maxdist[N][O] = 1.50;  // N-O is ~ 1.40 A, plus 0.1 A error
+	mindist[O][N] = mindist[N][O];  // N=O is ~ 1.21 A, minus 0.1A error
+	maxdist[O][N] = maxdist[N][O];  // N-O is ~ 1.40 A, plus 0.1 A error
 
-	//There is no bond between two hydrogenes (does not derive from Autodock)
-	mindist[3][3] = 2;
-	maxdist[3][3] = 1;
+	//There is no bond between two hydrogens (does not derive from Autodock)
+	mindist[H][H] = 2;
+	maxdist[H][H] = 1;
+#endif
 
 	for (atom_id1=0; atom_id1 < myligand->num_of_atoms-1; atom_id1++)
 	{


### PR DESCRIPTION
This code adds AD4 minimum and maximum bond distances (from AD4.2.6) as the ones in AD-GPU currently are not complete, particularly when compared to the current versions of AD4.2.