### PR TITLE
Use base name of grid maps file (fld) specified by user as the base name for map lookup

### DIFF
--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -66,6 +66,7 @@ typedef struct
 	char  grid_file_path[2*_MAX_DIR];	  // Added to store the full path of the grid file
 #endif
 	char   receptor_name [64];
+	char   map_base_name [64];
 	int    size_xyz [3];
 	double spacing;
 	double size_xyz_angstr [3];

--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -65,6 +65,16 @@ int get_gridinfo(const char* fldfilename, Gridinfo* mygrid)
 		return 1;
 	}
 
+	const char* ext = strstr(fldfilename,".maps");
+	if(ext){
+		char tmp[64];
+		int len=ext-fldfilename;
+		strncpy(tmp,fldfilename,len);
+		tmp[len]='\0';
+		strcpy(mygrid->map_base_name,tmp);
+	} else
+		strcpy(mygrid->map_base_name,fldfilename);
+
 	while (fscanf(fp, "%s", tempstr) != EOF)
 	{
 		// -----------------------------------
@@ -167,18 +177,20 @@ int get_gridvalues_f(const Gridinfo* mygrid, float* fgrids, bool cgmaps)
 	for (t=0; t < mygrid->num_of_atypes+2; t++)
 	{
 		//opening corresponding .map file
-		//-------------------------------------
-		// Added the complete path of associated grid files.
-		strcpy(tempstr,mygrid->grid_file_path);
-		strcat(tempstr, "/");
-		strcat(tempstr, mygrid->receptor_name);
-		
-		//strcpy(tempstr, mygrid->receptor_name);
-		//-------------------------------------
+		strcpy(tempstr,mygrid->map_base_name);
 		strcat(tempstr, ".");
 		strcat(tempstr, mygrid->grid_types[t]);
 		strcat(tempstr, ".map");
 		fp = fopen(tempstr, "rb"); // fp = fopen(tempstr, "r");
+		if (fp == NULL){ // try again with the receptor name in the .maps.fld file
+			strcpy(tempstr,mygrid->grid_file_path);
+			strcat(tempstr, "/");
+			strcat(tempstr, mygrid->receptor_name);
+			strcat(tempstr, ".");
+			strcat(tempstr, mygrid->grid_types[t]);
+			strcat(tempstr, ".map");
+			fp = fopen(tempstr, "rb"); // fp = fopen(tempstr, "r");
+		}
 		if (fp == NULL)
 		{
 			printf("Error: can't open %s!\n", tempstr);
@@ -214,8 +226,8 @@ int get_gridvalues_f(const Gridinfo* mygrid, float* fgrids, bool cgmaps)
 					if(y>0 && z>0) *(mypoi-4*(g2+g1)+3) = *mypoi;
 					mypoi+=4;
 				}
+		fclose(fp);
 	}
-
 	return 0;
 }
 

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -231,19 +231,21 @@ int load_all_maps (const char* fldfilename, const Gridinfo* mygrid, std::vector<
         {
 		all_maps[t].grid.resize(size_of_one_map);
 		float* mypoi = all_maps[t].grid.data();
-                //opening corresponding .map file
-                //-------------------------------------
-                // Added the complete path of associated grid files.
-                strcpy(tempstr,mygrid->grid_file_path);
-                strcat(tempstr, "/");
-                strcat(tempstr, mygrid->receptor_name);
-
-                //strcpy(tempstr, mygrid->receptor_name);
-                //-------------------------------------
+		//opening corresponding .map file
+		strcpy(tempstr,mygrid->map_base_name);
                 strcat(tempstr, ".");
                 strcat(tempstr, all_maps[t].atype.c_str());
                 strcat(tempstr, ".map");
                 fp = fopen(tempstr, "rb"); // fp = fopen(tempstr, "r");
+		if (fp == NULL){ // try again with the receptor name in the .maps.fld file
+			strcpy(tempstr,mygrid->grid_file_path);
+			strcat(tempstr, "/");
+			strcat(tempstr, mygrid->receptor_name);
+			strcat(tempstr, ".");
+			strcat(tempstr, mygrid->grid_types[t]);
+			strcat(tempstr, ".map");
+			fp = fopen(tempstr, "rb"); // fp = fopen(tempstr, "r");
+		}
                 if (fp == NULL)
                 {
                         printf("Error: can't open %s!\n", tempstr);


### PR DESCRIPTION
This PR changes the current behavior of using the receptor name entry in the grid file as the base name for maps to using the base name (including directories) of the grid file itself. The reason I think this is sane is because the grid map file is created with the same base name as the maps at time of creation. The code will use the receptor name as the base name in case a map with the grid file base name does not exist. This PR should address issue #84 and portions of #42.

I did test for correct operation on all my machines. Please test on yours.