### PR TITLE
Add NVIDIA Tesla P100 support

### DIFF
--- a/Makefile.Cuda
+++ b/Makefile.Cuda
@@ -15,7 +15,7 @@ NVCC = nvcc
 CPP = g++
 UNAME := $(shell uname)
 
-TARGETS = 52 61 70
+TARGETS = 52 60 61 70
 CUDA_TARGETS=$(foreach target,$(TARGETS),-gencode arch=compute_$(target),code=sm_$(target))
 
 $(shell ./link_cuda.sh)


### PR DESCRIPTION
CUDA version was not working on NVIDIA Tesla P100 GPU. Adding the number 60 to TARGETS fixed it. 
This is the answer for issue #91 
