### PR TITLE
Added option to not specify resnames in file list back in.

### DIFF
--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -117,7 +117,7 @@ int get_filelist(const int* argc,
 			printf("\nError: No ligands, through lines ending with the .pdbqt suffix, have been specified.\n");
 			return 1;
 		}
-		if (filelist.ligand_files.size() != filelist.resnames.size()){
+		if ((filelist.ligand_files.size() != filelist.resnames.size()) && (filelist.resnames.size()>0)){
 			printf("\nError: Inconsistent number of resnames (%lu) compared to ligands (%lu)!\n",filelist.resnames.size(),filelist.ligand_files.size());
 			return 1;
 		}


### PR DESCRIPTION
Mea culpa. I accidentally took out the ability to not specify a resname in the file list. Fixed it here.