### PR TITLE
Optimization of results processing

### DIFF
--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -231,6 +231,7 @@ struct IntraTables{
         //is only one ligand during the run of the program...)
         float q1q2 [MAX_NUM_OF_ATOMS][MAX_NUM_OF_ATOMS];
         float qasp_mul_absq [MAX_NUM_OF_ATOMS];
+        bool is_HB [MAX_NUM_OF_ATYPES] [MAX_NUM_OF_ATYPES];
 
         // Fill intraE tables
         IntraTables(const Liganddata* myligand,
@@ -239,6 +240,9 @@ struct IntraTables{
                     const float qasp){
                 calc_distdep_tables_f(r_6_table, r_10_table, r_12_table, r_epsr_table, desolv_table, scaled_AD4_coeff_elec, AD4_coeff_desolv);
                 calc_q_tables_f(myligand, qasp, q1q2, qasp_mul_absq);
+                for (unsigned int type_id1=0; type_id1<myligand->num_of_atypes; type_id1++)
+                    for (unsigned int type_id2=0; type_id2<myligand->num_of_atypes; type_id2++)
+                        is_HB [type_id1][type_id2] = (is_H_bond(myligand->atom_types [type_id1], myligand->atom_types [type_id2]) != 0);
         }
 };
 

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -2252,7 +2252,7 @@ float calc_intraE_f(const Liganddata* myligand,
 				// 	 (sum of the vdW radii of two like atoms (A)) in the case of hbond
 				float opt_distance;
 
-				if (is_H_bond(myligand->atom_types [type_id1], myligand->atom_types [type_id2]) != 0)	//H-bond
+				if (tables.is_HB [type_id1][type_id2])	//H-bond
 				{
 					opt_distance = myligand->reqm_hbond [atom1_type_vdw_hb] + myligand->reqm_hbond [atom2_type_vdw_hb];
 				}
@@ -2288,7 +2288,7 @@ float calc_intraE_f(const Liganddata* myligand,
 
 				if (dist < dcutoff) //but only if the distance is less than distance cutoff value
 				{
-					if (is_H_bond(myligand->atom_types [type_id1], myligand->atom_types [type_id2]) != 0)	//H-bond
+					if (tables.is_HB [type_id1][type_id2])	//H-bond
 					{
 						vdW1 = myligand->VWpars_C [type_id1][type_id2]*tables.r_12_table [smoothed_distance_id];
 						vdW2 = myligand->VWpars_D [type_id1][type_id2]*tables.r_10_table [smoothed_distance_id];


### PR DESCRIPTION
This small optimization speeds up the results processing between "immeasurable" (at `nrun=10`) to about 33% (at `nrun=100`).

On our Titan V node for Diogo's 42, for example, it reduced the cumulative "idle time" portion, which contains the results processing, for `nrun=100` from about 90 seconds down to about 60 seconds.