### PR TITLE
Support for naming the initial population file

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ By default the output log file is written in the current working folder. Example
 | -initswgens | Initial # generations of Solis-Wets instead of -lsmet | 0                |
 | -filelist   | Batch file                                            | no default       |
 | -xmloutput  | Specify if xml output format is wanted                | 1 (yes)          |
+| -initpopfn  | Name of initial population file                       | _"initpop.txt"_  |
 
 When the heuristics is used and `-nev <max evals>` is provided as a command line argument it provides the (hard) upper # of evals limit to the value the heuristics suggests. Conversely, `-heurmax` is the rolling-off type asymptotic limit to the heuristic's # of evals formula and should only be changed with caution.
 The batch file is a text file containing the parameters to -ffile, -lfile, and -resnam each on an individual line. It is possible to only use one line to specify the Protein grid map file which means it will be used for all ligands. Here is an example:

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -73,6 +73,7 @@ typedef struct
 	unsigned long max_num_of_iters;
 	unsigned long pop_size;
 		bool  initpop_gen_or_loadfile;
+		char  initpop_filename [128];
 		int   gen_pdbs;
 		char  fldfile [128];
 		char  ligandfile [128];

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -272,6 +272,7 @@ void get_commandpars(const int* argc,
 	mypars->max_num_of_iters	= 300;
 	mypars->pop_size		= 150;
 	mypars->initpop_gen_or_loadfile	= false;
+        strcpy(mypars->initpop_filename, "initpop.txt");
 	mypars->gen_pdbs		= 0;
 
 	mypars->autostop		= 0;
@@ -595,6 +596,14 @@ void get_commandpars(const int* argc,
 				mypars->initpop_gen_or_loadfile = true;
 		}
 
+		//Argument: name of the initial population file.
+		//If not provided, will default to "initpop.txt".
+		if (strcmp("-initpopfn", argv [i]) == 0)
+		{
+			arg_recognized = 1;
+			strcpy(mypars->initpop_filename, argv [i+1]);
+		}
+
 		//Argument: number of pdb files to be generated.
 		//The files will include the best docking poses from the final population.
 		if (strcmp("-npdb", argv [i]) == 0)
@@ -890,15 +899,15 @@ void gen_initpop_and_reflig(Dockpars*       mypars,
 	{
 		if (mypars->num_of_runs != 1)
 		{
-			printf("Warning: more than 1 run was requested. New populations will be generated \ninstead of being loaded from initpop.txt\n");
+			printf("Warning: more than 1 run was requested. New populations will be generated \ninstead of being loaded from %.*s\n", (int)sizeof(mypars->initpop_filename), mypars->initpop_filename);
 			gen_pop = 1;
 		}
 		else
 		{
-			fp = fopen("initpop.txt","rb"); // fp = fopen("initpop.txt","r");
+			fp = fopen(mypars->initpop_filename,"rb");
 			if (fp == NULL)
 			{
-				printf("Warning: can't find initpop.txt. A new population will be generated.\n");
+				printf("Warning: can't find %.*s. A new population will be generated.\n", (int)sizeof(mypars->initpop_filename), mypars->initpop_filename);
 				gen_pop = 1;
 			}
 			else
@@ -977,9 +986,9 @@ void gen_initpop_and_reflig(Dockpars*       mypars,
 		}
 
 		//Writing first initial population to initpop.txt
-		fp = fopen("initpop.txt", "w");
+		fp = fopen(mypars->initpop_filename, "w");
 		if (fp == NULL)
-			printf("Warning: can't create initpop.txt.\n");
+			printf("Warning: can't create %.*s.\n", (int)sizeof(mypars->initpop_filename),  mypars->initpop_filename);
 		else
 		{
 			for (entity_id=0; entity_id<pop_size; entity_id++)

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -272,7 +272,7 @@ void get_commandpars(const int* argc,
 	mypars->max_num_of_iters	= 300;
 	mypars->pop_size		= 150;
 	mypars->initpop_gen_or_loadfile	= false;
-        strcpy(mypars->initpop_filename, "initpop.txt");
+	strcpy(mypars->initpop_filename, "initpop.txt");
 	mypars->gen_pdbs		= 0;
 
 	mypars->autostop		= 0;


### PR DESCRIPTION
**Problem:** The "initpop.txt" filename is hardcoded which can be problematic if multiple autodock processes are running from the same directory. Increasing the number of concurrent processes can cause filelocking on initpop.txt and will significantly slow down average docking times, even for a modest number of processes (e.g. 20 GPUs) and a relatively small virtual screening task (1 protein, 84K ligands).

![ad_orig](https://user-images.githubusercontent.com/11857072/100970520-b3539600-34fa-11eb-8e5c-8822af772fef.png)

**Why its important:** Many HPC centers support parametric launchers as a way to break up large jobs into small, embarrassingly parallel jobs distributed over available resources - e.g. [launcher](https://github.com/TACC/launcher). A simple workaround would be to run concurrent instances from their own directories so there will be no filelocking on initpop.txt. However, not all parametric launchers natively support that, and adding logic to create / switch directories can be clunky and disorganizing.

**Proposed solution:** Giving the user the opportunity to specify the initpop file name on the command line with the _-initpopfn_ flag avoids the issue in a more direct, clean way. All processes can run from the same directory, and if unique initpop filenames are given to each process, no slow down from filelocking will occur.

![ad_mod](https://user-images.githubusercontent.com/11857072/100972875-2828cf00-34ff-11eb-9b05-7d04fd6b2b3c.png)

The new _-initpopfn_ flag is not required, and the name of the file will default to "initpop.txt" if the flag is not provided.

**Example usage:** An example of this in practice is splitting a virtual screening library up into equal size chunks, and running each chunk concurrently. The list of concurrent commands running on a node with 4 GPUs may resemble:

```
autodock_gpu_64wi -initpopfn initpop1.txt -devnum 1 -filelist batch1 > output1.log
autodock_gpu_64wi -initpopfn initpop2.txt -devnum 2 -filelist batch2 > output2.log
autodock_gpu_64wi -initpopfn initpop3.txt -devnum 3 -filelist batch3 > output3.log
autodock_gpu_64wi -initpopfn initpop4.txt -devnum 4 -filelist batch4 > output4.log
```