### PR TITLE
Support to read AD4's dpf input files and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ By default the output log file is written in the current working folder. Example
 | -crat       | Crossover rate                                        | 80 (%)           |
 | -lsrat      | Local-search rate                                     | 80 (%)           |
 | -trat       | Tournament (selection) rate                           | 60 (%)           |
-| -resnam     | Name for docking output log                           | _"docking"_      |
+| -resnam     | Name for docking output log                           | ligand basename  |
 | -hsym       | Handle symmetry in RMSD calc.                         | 1                |
 | -devnum     | OpenCL/Cuda device number (counting starts at 1)      | 1                |
 | -cgmaps     | Use individual maps for CG-G0 instead of the same one | 0 (use same map) |

--- a/common/calcenergy_basic.h
+++ b/common/calcenergy_basic.h
@@ -78,6 +78,9 @@ typedef enum
 // Sticking to array boundaries
 #define stick_to_bounds(x,a,b) x + (x <= a)*(a-x) + (x >= b)*(b-x)
 
+// e^2/4pie0 in kcal/mol
+#define ELEC_SCALE_FACTOR        332.06363
+
 // Constants for dielelectric term of the
 // electrostatic component of the intramolecular energy/gradient
 #define DIEL_A                   -8.5525f

--- a/common/defines.h
+++ b/common/defines.h
@@ -99,5 +99,10 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 // does not return better accuracy overall (default: commented out, don't use)
 // #define DIEL_FIT_ABC
 
+// Output for the -derivtype keyword
+// #define DERIVTYPE_INFO
+
+// Output for the -modpair keyword
+// #define MODPAIR_INFO
 
 #endif /* DEFINES_H_ */

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -356,7 +356,7 @@ __device__ void gpu_calc_energy(
 	// are independent from each other, -> NO BARRIER NEEDED
 	// but require different operations,
 	// thus, they can be executed only sequentially on the GPU.
-	float delta_distance = 0.5f * cData.dockpars.smooth; 
+	float delta_distance = 0.5f * cData.dockpars.smooth;
 	float smoothed_distance;
 
 	// ================================================

--- a/device/kernel3.cl
+++ b/device/kernel3.cl
@@ -76,9 +76,9 @@ __constant       kernelconstant_conform*      kerconst_conform
 // it is always tested according to the ls probability, and if it not to be
 // subjected to local search, the entity with ID num_of_lsentities is selected instead of the first one (with ID 0).
 {
-	// Some OpenCL compilers don't allow declaring 
+	// Some OpenCL compilers don't allow declaring
 	// local variables within non-kernel functions.
-	// These local variables must be declared in a kernel, 
+	// These local variables must be declared in a kernel,
 	// and then passed to non-kernel functions.
 	__local float genotype_candidate[ACTUAL_GENOTYPE_LENGTH];
 	__local float genotype_deviate  [ACTUAL_GENOTYPE_LENGTH];
@@ -149,7 +149,6 @@ __constant       kernelconstant_conform*      kerconst_conform
 
 	// Asynchronous copy should be finished by here
 	wait_group_events(1, &ev);
-
 	barrier(CLK_LOCAL_MEM_FENCE);
 
 #ifdef SWAT3
@@ -304,41 +303,41 @@ __constant       kernelconstant_conform*      kerconst_conform
 			                 dockpars_gridsize_x,
 			                 dockpars_gridsize_y,
 			                 dockpars_gridsize_z,
-			                 		    	// g1 = gridsize_x
-			                dockpars_gridsize_x_times_y, 		// g2 = gridsize_x * gridsize_y
-			                dockpars_gridsize_x_times_y_times_z,	// g3 = gridsize_x * gridsize_y * gridsize_z
-			                dockpars_fgrids,
-			                dockpars_num_of_atypes,
-			                dockpars_num_of_map_atypes,
-			                dockpars_num_of_intraE_contributors,
-			                dockpars_grid_spacing,
-			                dockpars_coeff_elec,
-			                dockpars_elec_min_distance,
-			                dockpars_qasp,
-			                dockpars_coeff_desolv,
-			                dockpars_smooth,
-			                genotype_candidate,
-			                &candidate_energy,
-			                &run_id,
-			                // Some OpenCL compilers don't allow declaring
-			                // local variables within non-kernel functions.
-			                // These local variables must be declared in a kernel,
-			                // and then passed to non-kernel functions.
-			                calc_coords,
-			                partial_energies,
-			                #if defined (DEBUG_ENERGY_KERNEL)
-			                partial_interE,
-			                partial_intraE,
-			                #endif
+			                                                      // g1 = gridsize_x
+			                 dockpars_gridsize_x_times_y,         // g2 = gridsize_x * gridsize_y
+			                 dockpars_gridsize_x_times_y_times_z, // g3 = gridsize_x * gridsize_y * gridsize_z
+			                 dockpars_fgrids,
+			                 dockpars_num_of_atypes,
+			                 dockpars_num_of_map_atypes,
+			                 dockpars_num_of_intraE_contributors,
+			                 dockpars_grid_spacing,
+			                 dockpars_coeff_elec,
+			                 dockpars_elec_min_distance,
+			                 dockpars_qasp,
+			                 dockpars_coeff_desolv,
+			                 dockpars_smooth,
+			                 genotype_candidate,
+			                 &candidate_energy,
+			                 &run_id,
+			                 // Some OpenCL compilers don't allow declaring
+			                 // local variables within non-kernel functions.
+			                 // These local variables must be declared in a kernel,
+			                 // and then passed to non-kernel functions.
+			                 calc_coords,
+			                 partial_energies,
+			                 #if defined (DEBUG_ENERGY_KERNEL)
+			                 partial_interE,
+			                 partial_intraE,
+			                 #endif
 #if 0
-			                false,
+			                 false,
 #endif
-			                kerconst_interintra,
-			                kerconst_intracontrib,
-			                kerconst_intra,
-			                kerconst_rotlist,
-			                kerconst_conform
-			              );
+			                 kerconst_interintra,
+			                 kerconst_intracontrib,
+			                 kerconst_intra,
+			                 kerconst_rotlist,
+			                 kerconst_conform
+			               );
 			// =================================================================
 
 			if (tidx == 0) {
@@ -418,18 +417,15 @@ __constant       kernelconstant_conform*      kerconst_conform
 	}
 
 	// Mapping torsion angles
-	for (gene_counter = tidx;
+	for (gene_counter = tidx+3;
 	     gene_counter < dockpars_num_of_genes;
 	     gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 	{
-		if (gene_counter >= 3) {
-			map_angle(&(offspring_genotype[gene_counter]));
-		}
+		map_angle(&(offspring_genotype[gene_counter]));
 	}
 
 	// Updating old offspring in population
 	barrier(CLK_LOCAL_MEM_FENCE);
-
 	event_t ev2 = async_work_group_copy(dockpars_conformations_next+(run_id*dockpars_pop_size+entity_id)*GENOTYPE_LENGTH_IN_GLOBMEM,
 	                                    offspring_genotype,
 	                                    dockpars_num_of_genes,0);

--- a/device/kernel4.cl
+++ b/device/kernel4.cl
@@ -70,7 +70,7 @@ gpu_gen_and_eval_newpops(
               __constant       kernelconstant_rotlist*      kerconst_rotlist,
               __constant       kernelconstant_conform*      kerconst_conform
                         )
-//The GPU global function
+// The GPU global function
 {
 	// Some OpenCL compilers don't allow declaring 
 	// local variables within non-kernel functions.
@@ -150,7 +150,7 @@ gpu_gen_and_eval_newpops(
 			// Notice: dockpars_tournament_rate was scaled down to [0,1] in host
 			// to reduce number of operations in device
 			if (candidate_energies[2*gene_counter] < candidate_energies[2*gene_counter+1])
-				if (/*100.0f**/randnums[4+gene_counter] < dockpars_tournament_rate) {		//using randnum[4..5]
+				if (/*100.0f**/randnums[4+gene_counter] < dockpars_tournament_rate) { //using randnum[4..5]
 					parents[gene_counter] = parent_candidates[2*gene_counter];
 				}
 				else {
@@ -170,7 +170,7 @@ gpu_gen_and_eval_newpops(
 
 		// Notice: dockpars_crossover_rate was scaled down to [0,1] in host
 		// to reduce number of operations in device
-		if (/*100.0f**/randnums[6] < dockpars_crossover_rate)	// Using randnums[6]
+		if (/*100.0f**/randnums[6] < dockpars_crossover_rate) // Using randnums[6]
 		{
 			for (gene_counter = tidx;
 			     gene_counter < 2;

--- a/host/inc/autostop.hpp
+++ b/host/inc/autostop.hpp
@@ -40,7 +40,6 @@ class AutoStop{
 	      float              curr_avg;
 	      float              curr_std;
 	      unsigned int       roll_count;
-	      float              rolling_stddev;
 	      unsigned int       bestN;
 	const unsigned int       Ntop;
 	const unsigned int       pop_size;
@@ -126,7 +125,7 @@ class AutoStop{
 	         float stopstd_in,
 	         int as_frequency_in
 	        )
-		: rolling(4*3, 0), // Initialize to zero
+		: rolling(4*4, 0), // Initialize to zero
 		  average_sd2_N((pop_size_in+1)*3),
 		  num_of_runs(num_of_runs_in),
 		  pop_size(pop_size_in),
@@ -184,16 +183,22 @@ class AutoStop{
 		}
 		printf("%11u | %12lu |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/num_of_runs,threshold_used,curr_avg,curr_std,bestN,overall_best_energy);
 		fflush(stdout);
-		rolling[3*roll_count] = curr_avg * bestN;
-		rolling[3*roll_count+1] = (curr_std*curr_std + curr_avg*curr_avg)*bestN;
-		rolling[3*roll_count+2] = bestN;
+		rolling[4*roll_count] = curr_avg * bestN;
+		rolling[4*roll_count+1] = (curr_std*curr_std + curr_avg*curr_avg)*bestN;
+		rolling[4*roll_count+2] = bestN;
+		rolling[4*roll_count+3] = overall_best_energy;
 		roll_count = (roll_count + 1) % 4;
-		average_sd2_N[0] = rolling[0] + rolling[3] + rolling[6] + rolling[9];
-		average_sd2_N[1] = rolling[1] + rolling[4] + rolling[7] + rolling[10];
-		average_sd2_N[2] = rolling[2] + rolling[5] + rolling[8] + rolling[11];
+		average_sd2_N[0] = rolling[0] + rolling[4] + rolling[8] + rolling[12];
+		average_sd2_N[1] = rolling[1] + rolling[5] + rolling[9] + rolling[13];
+		average_sd2_N[2] = rolling[2] + rolling[6] + rolling[10] + rolling[14];
+		float best_avg = rolling[3] + rolling[7] + rolling[11] + rolling[15];
+		best_avg /= 4;
+		float best_var = rolling[3]*rolling[3] + rolling[7]*rolling[7] + rolling[11]*rolling[11] + rolling[15]*rolling[15];
+		best_var /= 4;
+		best_var -= best_avg*best_avg;
 
-		// Finish when the std.dev. of the last 4 rounds is below 0.1 kcal/mol
-		if((stddev(&average_sd2_N[0])<stopstd) && (generation_cnt>=4*as_frequency))
+		// Finish when the std.dev. of the last 4 rounds is below -stopstd kcal/mol and are at (essentially) the same best energy
+		if((stddev(&average_sd2_N[0])<stopstd) && (generation_cnt>=4*as_frequency) && (best_var<=0.00002f))
 			autostopped = true;
 
 		return autostopped;

--- a/host/inc/autostop.hpp
+++ b/host/inc/autostop.hpp
@@ -148,7 +148,7 @@ class AutoStop{
 
 	inline void print_intro(unsigned long num_of_generations, unsigned long num_of_energy_evals)
 	{
-		printf("\nExecuting docking runs, stopping automatically after either reaching %.2f kcal/mol standard deviation of\nthe best molecules of the last 4 * %u generations, %u generations, or %u evaluations:\n\n",stopstd,as_frequency,num_of_generations,num_of_energy_evals);
+		printf("\nExecuting docking runs, stopping automatically after either reaching %.2f kcal/mol standard deviation of\nthe best molecules of the last 4 * %u generations, %lu generations, or %lu evaluations:\n\n",stopstd,as_frequency,num_of_generations,num_of_energy_evals);
 		printf("Generations |  Evaluations |     Threshold    |  Average energy of best 10%%  | Samples |    Best energy\n");
 		printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
 	}
@@ -209,9 +209,9 @@ class AutoStop{
 			tabulate_energies(energies);  // Fills average_sd2_N and overall_best_energy
 			set_stats(); // set curr_avg, curr_std, bestN, average_sd2_N
 
-			printf("%11u | %12u |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/num_of_runs,threshold,curr_avg,curr_std,bestN,overall_best_energy);
+			printf("%11u | %12lu |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/num_of_runs,threshold,curr_avg,curr_std,bestN,overall_best_energy);
 			printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
-			printf("\n%43s evaluation after reaching\n%33u evaluations. Best energy %8.2f kcal/mol.\n","Finished",total_evals/num_of_runs,overall_best_energy);
+			printf("\n%43s evaluation after reaching\n%33lu evaluations. Best energy %8.2f kcal/mol.\n","Finished",total_evals/num_of_runs,overall_best_energy);
 		}
 		fflush(stdout);
 	}

--- a/host/inc/filelist.hpp
+++ b/host/inc/filelist.hpp
@@ -40,7 +40,6 @@ class FileList{
 	bool                     used;
 	bool                     preload_maps;
 	bool                     maps_are_loaded;
-	bool                     load_maps_gpu;
 	char*                    filename;
 	int                      nfiles;
 	int                      max_len; // maximum length of strings in arrays below
@@ -49,9 +48,10 @@ class FileList{
 	std::vector<std::string> ligand_files;
 	std::vector<Dockpars>    mypars;
 	std::vector<Gridinfo>    mygrids;
+	std::vector<bool>        load_maps_gpu; // indicate which device needs to still load maps from cpu
 
 	// Default to unused, with 1 file
-	FileList() : used( false ), nfiles( 1 ), preload_maps( true ), maps_are_loaded( false ), load_maps_gpu( false ), filename( NULL ), max_len ( 0 ) {}
+	FileList() : used( false ), nfiles( 1 ), preload_maps( true ), maps_are_loaded( false ), filename( NULL ), max_len ( 0 ) {}
 	~FileList(){ if(filename) free(filename); }
 };
 

--- a/host/inc/filelist.hpp
+++ b/host/inc/filelist.hpp
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdlib.h>
 #include <string>
 #include <vector>
+#include "processgrid.h"
 
 typedef struct _Dockpars Dockpars;
 
@@ -47,6 +48,7 @@ class FileList{
 	std::vector<std::string> fld_files;
 	std::vector<std::string> ligand_files;
 	std::vector<Dockpars>    mypars;
+	std::vector<Gridinfo>    mygrids;
 
 	// Default to unused, with 1 file
 	FileList() : used( false ), nfiles( 1 ), preload_maps( true ), maps_are_loaded( false ), load_maps_gpu( false ), filename( NULL ), max_len ( 0 ) {}

--- a/host/inc/filelist.hpp
+++ b/host/inc/filelist.hpp
@@ -49,7 +49,7 @@ class FileList{
 	std::vector<Dockpars>    mypars;
 
 	// Default to unused, with 1 file
-	FileList() : used( false ), nfiles( 1 ), preload_maps( false ), maps_are_loaded( false ), load_maps_gpu( false ), filename( NULL ), max_len ( 0 ) {}
+	FileList() : used( false ), nfiles( 1 ), preload_maps( true ), maps_are_loaded( false ), load_maps_gpu( false ), filename( NULL ), max_len ( 0 ) {}
 	~FileList(){ if(filename) free(filename); }
 };
 

--- a/host/inc/filelist.hpp
+++ b/host/inc/filelist.hpp
@@ -31,6 +31,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <string>
 #include <vector>
 
+typedef struct _Dockpars Dockpars;
+
 class FileList{
 	public:
 
@@ -40,10 +42,11 @@ class FileList{
 	bool                     load_maps_gpu;
 	char*                    filename;
 	int                      nfiles;
-	int                      max_len; // maxium length of strings in arrays below
+	int                      max_len; // maximum length of strings in arrays below
 	std::vector<std::string> resnames;
 	std::vector<std::string> fld_files;
 	std::vector<std::string> ligand_files;
+	std::vector<Dockpars>    mypars;
 
 	// Default to unused, with 1 file
 	FileList() : used( false ), nfiles( 1 ), preload_maps( false ), maps_are_loaded( false ), load_maps_gpu( false ), filename( NULL ), max_len ( 0 ) {}

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -61,11 +61,10 @@ constexpr AD4_free_energy_coeffs unbound_models[3] = {
                                                       {0.1641,0.0531,ELEC_SCALE_FACTOR*0.1272,0.0603,0.2272}
                                                      };
 
-
 // Struct which contains the docking parameters (partly parameters for fpga)
 typedef struct _Dockpars
 {                                                              // default values
-	unsigned int           seed                            = time(NULL);
+	uint32_t               seed[3]                         = {(uint32_t)time(NULL),(uint32_t)processid(),0};
 	unsigned long          num_of_energy_evals             = 2500000;
 	unsigned long          num_of_generations              = 27000;
 	bool                   nev_provided                    = false;

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -64,6 +64,8 @@ constexpr AD4_free_energy_coeffs unbound_models[3] = {
 // Struct which contains the docking parameters (partly parameters for fpga)
 typedef struct _Dockpars
 {                                                              // default values
+	int                    devnum                          = -1;
+	int                    devices_requested               = 1; // this is AD-GPU ...
 	uint32_t               seed[3]                         = {(uint32_t)time(NULL),(uint32_t)processid(),0};
 	unsigned long          num_of_energy_evals             = 2500000;
 	unsigned long          num_of_generations              = 27000;
@@ -81,7 +83,6 @@ typedef struct _Dockpars
 	deriv_atype*           deriv_atypes                    = NULL; // or even: -derivtype C1,C2,C3=C/S4=S/H5=HD
 	int                    nr_mod_atype_pairs              = 0;    // this is to support: -modpair C1:S4,1.60,1.200,13,7
 	pair_mod*              mod_atype_pairs                 = NULL; // or even: -modpair C1:S4,1.60,1.200,13,7/C1:C3,1.20 0.025
-	unsigned long          num_of_ls;
 	char                   ls_method[LS_METHOD_STRING_LEN] = "sw"; // "sw": Solis-Wets,
 	                                                               // "sd": Steepest-Descent
 	                                                               // "fire": FIRE, https://www.math.uni-bielefeld.de/~gaehler/papers/fire.pdf
@@ -100,6 +101,7 @@ typedef struct _Dockpars
 	char*                  ligandfile                      = NULL;
 	char*                  flexresfile                     = NULL;
 	char*                  xrayligandfile                  = NULL;  // by default will be ligand file name
+	char*                  resname                         = NULL; // by default will be ligand file basename
 	bool                   given_xrayligandfile            = false; // That is, not given (explicitly by the user)
 	float                  ref_ori_angles [3];             // is generated in gen_initpop_and_reflig(...)
 	bool                   autostop                        = 0;
@@ -114,7 +116,6 @@ typedef struct _Dockpars
 	bool                   handle_symmetry                 = true;
 	bool                   gen_finalpop                    = false;
 	bool                   gen_best                        = false;
-	char*                  resname                         = NULL; // by default will be ligand file basename
 	float                  qasp                            = 0.01097f;
 	float                  rmsd_tolerance                  = 2.0; // 2 Angstroem
 	float                  adam_beta1                      = 0.9f;
@@ -154,6 +155,7 @@ int preparse_dpf(
                  const int*      argc,
                        char**    argv,
                        Dockpars* mypars,
+                       Gridinfo* mygrid,
                        FileList& filelist
                 );
 
@@ -161,6 +163,7 @@ int get_filelist(
                  const int*      argc,
                        char**    argv,
                        Dockpars* mypars,
+                       Gridinfo* mygrid,
                        FileList& filelist
                 );
 
@@ -171,12 +174,13 @@ int get_filenames_and_ADcoeffs(
                                const bool
                               );
 
-void get_commandpars(
-                     const int*,
-                           char**,
-                           double*,
-                           Dockpars*
-                    );
+int get_commandpars(
+                    const int*,
+                          char**,
+                          double*,
+                          Dockpars*,
+                    const bool late_call = true
+                   );
 
 void gen_initpop_and_reflig(
                                   Dockpars*   mypars,

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -97,6 +97,7 @@ typedef struct _Dockpars
 	unsigned long          pop_size                        = 150;
 	bool                   initpop_gen_or_loadfile         = false;
 	int                    gen_pdbs                        = 0;
+	char*                  dpffile                         = NULL;
 	char*                  fldfile                         = NULL;
 	char*                  ligandfile                      = NULL;
 	char*                  flexresfile                     = NULL;

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -68,22 +68,22 @@ typedef struct _Dockpars
 	int                    devices_requested               = 1; // this is AD-GPU ...
 	uint32_t               seed[3]                         = {(uint32_t)time(NULL),(uint32_t)processid(),0};
 	unsigned long          num_of_energy_evals             = 2500000;
-	unsigned long          num_of_generations              = 27000;
+	unsigned long          num_of_generations              = 42000;
 	bool                   nev_provided                    = false;
-	bool                   use_heuristics                  = false; // Flag if we want to use Diogo's heuristics
+	bool                   use_heuristics                  = true; // Flag if we want to use Diogo's heuristics
 	unsigned long          heuristics_max                  = 12000000; // Maximum number of evaluations under the heuristics (12M max evaluates to 80% of 3M evals calculated by heuristics -> 2.4M)
 	float                  abs_max_dmov;                   // depends on grid spacing
 	float                  abs_max_dang                    = 90; // +/- 90°
 	float                  mutation_rate                   = 2;  // 2%
 	float                  crossover_rate                  = 80; // 80%
 	float                  tournament_rate                 = 60; // 60%
-	float                  lsearch_rate                    = 80; // 80%
+	float                  lsearch_rate                    = 100; // 1000%
 	float                  smooth                          = 0.5f;
 	int                    nr_deriv_atypes                 = 0;    // this is to support: -derivtype C1,C2,C3=C
 	deriv_atype*           deriv_atypes                    = NULL; // or even: -derivtype C1,C2,C3=C/S4=S/H5=HD
 	int                    nr_mod_atype_pairs              = 0;    // this is to support: -modpair C1:S4,1.60,1.200,13,7
 	pair_mod*              mod_atype_pairs                 = NULL; // or even: -modpair C1:S4,1.60,1.200,13,7/C1:C3,1.20 0.025
-	char                   ls_method[LS_METHOD_STRING_LEN] = "sw"; // "sw": Solis-Wets,
+	char                   ls_method[LS_METHOD_STRING_LEN] = "ad"; // "sw": Solis-Wets,
 	                                                               // "sd": Steepest-Descent
 	                                                               // "fire": FIRE, https://www.math.uni-bielefeld.de/~gaehler/papers/fire.pdf
 	                                                               // "ad": ADADELTA, https://arxiv.org/abs/1212.5701
@@ -105,7 +105,7 @@ typedef struct _Dockpars
 	char*                  resname                         = NULL; // by default will be ligand file basename
 	bool                   given_xrayligandfile            = false; // That is, not given (explicitly by the user)
 	float                  ref_ori_angles [3];             // is generated in gen_initpop_and_reflig(...)
-	bool                   autostop                        = 0;
+	bool                   autostop                        = true;
 	unsigned int           as_frequency                    = 5;
 	float                  stopstd                         = 0.15;
 	bool                   cgmaps                          = false; // default is false (use a single map for every CGx or Gx atom type)

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -71,7 +71,7 @@ typedef struct _Dockpars
 	unsigned long          num_of_generations              = 27000;
 	bool                   nev_provided                    = false;
 	bool                   use_heuristics                  = false; // Flag if we want to use Diogo's heuristics
-	unsigned long          heuristics_max                  = 50000000; // Maximum number of evaluations under the heuristics (50M evaluates to 80% at 12.5M evals calculated by heuristics)
+	unsigned long          heuristics_max                  = 12000000; // Maximum number of evaluations under the heuristics (12M max evaluates to 80% of 3M evals calculated by heuristics -> 2.4M)
 	float                  abs_max_dmov;                   // depends on grid spacing
 	float                  abs_max_dang                    = 90; // +/- 90°
 	float                  mutation_rate                   = 2;  // 2%

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <string.h>
 #include <stdio.h>
 #include <vector>
+#include <time.h>
 
 #include "defines.h"
 #include "processligand.h"
@@ -49,63 +50,78 @@ typedef struct
 	double AD4_coeff_tors;
 } AD4_free_energy_coeffs;
 
+// this needs to be a constexpr so it's resolved at compile time and not an object in multiple .o files
+// (requires GCC > 4.9.0 which had a bug)
+constexpr AD4_free_energy_coeffs unbound_models[3] = {
+                                                      /* this model assumes the BOUND conformation is the SAME as the UNBOUND, default in AD4.2 */
+                                                      {0.1662,0.1209,ELEC_SCALE_FACTOR*0.1406,0.1322,0.2983},
+                                                      /* this model assumes the unbound conformation is EXTENDED, default if AD4.0 */
+                                                      {0.1560,0.0974,ELEC_SCALE_FACTOR*0.1465,0.1159,0.2744},
+                                                      /* this model assumes the unbound conformation is COMPACT */
+                                                      {0.1641,0.0531,ELEC_SCALE_FACTOR*0.1272,0.0603,0.2272}
+                                                     };
+
+
 // Struct which contains the docking parameters (partly parameters for fpga)
-typedef struct
-{
-	unsigned int           seed;
-	unsigned long          num_of_energy_evals;
-	unsigned long          num_of_generations;
-	bool                   nev_provided;
-	bool                   use_heuristics;
-	unsigned long          heuristics_max;
-	float                  abs_max_dmov;
-	float                  abs_max_dang;
-	float                  mutation_rate;
-	float                  crossover_rate;
-	float                  lsearch_rate;
-	float                  smooth;
-	bool*                  ignore_inter;
-	int                    nr_deriv_atypes;
-	deriv_atype*           deriv_atypes;
-	int                    nr_mod_atype_pairs;
-	pair_mod*              mod_atype_pairs;
+typedef struct _Dockpars
+{                                                              // default values
+	unsigned int           seed                            = time(NULL);
+	unsigned long          num_of_energy_evals             = 2500000;
+	unsigned long          num_of_generations              = 27000;
+	bool                   nev_provided                    = false;
+	bool                   use_heuristics                  = false; // Flag if we want to use Diogo's heuristics
+	unsigned long          heuristics_max                  = 50000000; // Maximum number of evaluations under the heuristics (50M evaluates to 80% at 12.5M evals calculated by heuristics)
+	float                  abs_max_dmov;                   // depends on grid spacing
+	float                  abs_max_dang                    = 90; // +/- 90°
+	float                  mutation_rate                   = 2;  // 2%
+	float                  crossover_rate                  = 80; // 80%
+	float                  tournament_rate                 = 60; // 60%
+	float                  lsearch_rate                    = 80; // 80%
+	float                  smooth                          = 0.5f;
+	int                    nr_deriv_atypes                 = 0;    // this is to support: -derivtype C1,C2,C3=C
+	deriv_atype*           deriv_atypes                    = NULL; // or even: -derivtype C1,C2,C3=C/S4=S/H5=HD
+	int                    nr_mod_atype_pairs              = 0;    // this is to support: -modpair C1:S4,1.60,1.200,13,7
+	pair_mod*              mod_atype_pairs                 = NULL; // or even: -modpair C1:S4,1.60,1.200,13,7/C1:C3,1.20 0.025
 	unsigned long          num_of_ls;
-	char                   ls_method[LS_METHOD_STRING_LEN];
-	int                    initial_sw_generations;
-	float                  tournament_rate;
-	float                  rho_lower_bound;
-	float                  base_dmov_mul_sqrt3;
-	float                  base_dang_mul_sqrt3;
-	unsigned long          cons_limit;
-	unsigned long          max_num_of_iters;
-	unsigned long          pop_size;
-	bool                   initpop_gen_or_loadfile;
-	int                    gen_pdbs;
-	char*                  fldfile = NULL;
-	char*                  ligandfile = NULL;
-	char*                  flexresfile = NULL;
-	char*                  xrayligandfile = NULL;
-	bool                   given_xrayligandfile;
-	float                  ref_ori_angles [3];
-	bool                   autostop;
-	unsigned int           as_frequency;
-	float                  stopstd;
-	bool                   cgmaps;
-	unsigned long          num_of_runs;
-	bool                   reflig_en_required;
-	int                    unbound_model;
-	AD4_free_energy_coeffs coeffs;
-	float                  elec_min_distance;
-	bool                   handle_symmetry;
-	bool                   gen_finalpop;
-	bool                   gen_best;
-	char*                  resname = NULL;
-	float                  qasp;
-	float                  rmsd_tolerance;
-	float                  adam_beta1;
-	float                  adam_beta2;
-	float                  adam_epsilon;
-	bool                   output_xml;
+	char                   ls_method[LS_METHOD_STRING_LEN] = "sw"; // "sw": Solis-Wets,
+	                                                               // "sd": Steepest-Descent
+	                                                               // "fire": FIRE, https://www.math.uni-bielefeld.de/~gaehler/papers/fire.pdf
+	                                                               // "ad": ADADELTA, https://arxiv.org/abs/1212.5701
+	                                                               // "adam": ADAM (currently only on Cuda)
+	int                    initial_sw_generations          = 0;
+	float                  rho_lower_bound                 = 0.01; // 0.01;
+	float                  base_dmov_mul_sqrt3;            // depends on grid spacing
+	float                  base_dang_mul_sqrt3             = 75.0*sqrt(3.0); // 75°
+	unsigned long          cons_limit                      = 4;
+	unsigned long          max_num_of_iters                = 300;
+	unsigned long          pop_size                        = 150;
+	bool                   initpop_gen_or_loadfile         = false;
+	int                    gen_pdbs                        = 0;
+	char*                  fldfile                         = NULL;
+	char*                  ligandfile                      = NULL;
+	char*                  flexresfile                     = NULL;
+	char*                  xrayligandfile                  = NULL;  // by default will be ligand file name
+	bool                   given_xrayligandfile            = false; // That is, not given (explicitly by the user)
+	float                  ref_ori_angles [3];             // is generated in gen_initpop_and_reflig(...)
+	bool                   autostop                        = 0;
+	unsigned int           as_frequency                    = 5;
+	float                  stopstd                         = 0.15;
+	bool                   cgmaps                          = false; // default is false (use a single map for every CGx or Gx atom type)
+	unsigned long          num_of_runs                     = 1;
+	bool                   reflig_en_required              = false;
+	int                    unbound_model                   = 0;                 // bound same as unbound, the coefficients
+	AD4_free_energy_coeffs coeffs                          = unbound_models[0]; // are also set in get_filenames_and_ADcoeffs()
+	float                  elec_min_distance               = 0.01;
+	bool                   handle_symmetry                 = true;
+	bool                   gen_finalpop                    = false;
+	bool                   gen_best                        = false;
+	char*                  resname                         = NULL; // by default will be "docking", dynamically created
+	float                  qasp                            = 0.01097f;
+	float                  rmsd_tolerance                  = 2.0; // 2 Angstroem
+	float                  adam_beta1                      = 0.9f;
+	float                  adam_beta2                      = 0.999f;
+	float                  adam_epsilon                    = 1.0e-8f;
+	bool                   output_xml                      = true; // xml output file will be generated
 } Dockpars;
 
 inline bool add_deriv_atype(
@@ -135,9 +151,17 @@ inline bool add_deriv_atype(
 	return true;
 }
 
+int preparse_dpf(
+                 const int*      argc,
+                       char**    argv,
+                       Dockpars* mypars,
+                       FileList& filelist
+                );
+
 int get_filelist(
                  const int*      argc,
                        char**    argv,
+                       Dockpars* mypars,
                        FileList& filelist
                 );
 
@@ -162,6 +186,23 @@ void gen_initpop_and_reflig(
                                   Liganddata* myligand,
                             const Gridinfo*   mygrid
                            );
+
+// these are the dpf file tokens we currently support -- although some by ignoring them ;-)
+enum {DPF_UNKNOWN = -1,    DPF_NULL = 0,          DPF_COMMENT,      DPF_BLANK_LINE,
+      DPF_MOVE,            DPF_FLD,               DPF_MAP,          DPF_ABOUT,
+      DPF_TRAN0,           DPF_AXISANGLE0,        DPF_QUATERNION0,  DPF_QUAT0,
+      DPF_DIHE0,           DPF_NDIHE,             DPF_TORSDOF,      DPF_INTNBP_COEFFS,
+      DPF_INTNBP_REQM_EPS, DPF_RUNS,              DPF_GALS,         DPF_OUTLEV,
+      DPF_RMSTOL,          DPF_EXTNRG,            DPF_INTELEC,      DPF_SMOOTH,
+      DPF_SEED,            DPF_E0MAX,             DPF_SET_GA,       DPF_SET_SW1,
+      DPF_SET_PSW1,        DPF_ANALYSIS,          GA_pop_size,      GA_num_generations,
+      GA_num_evals,        GA_window_size,        GA_elitism,       GA_mutation_rate,
+      GA_crossover_rate,   GA_Cauchy_alpha,       GA_Cauchy_beta,   SW_max_its,
+      SW_max_succ,         SW_max_fail,           SW_rho,           SW_lb_rho,
+      LS_search_freq,      DPF_PARAMETER_LIBRARY, DPF_LIGAND_TYPES, DPF_POPFILE,
+      DPF_FLEXRES,         DPF_ELECMAP,           DPF_DESOLVMAP,    DPF_UNBOUND_MODEL};
+
+int dpf_token(const char* token);
 
 #endif /* GETPARAMETERS_H_ */
 

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -114,7 +114,7 @@ typedef struct _Dockpars
 	bool                   handle_symmetry                 = true;
 	bool                   gen_finalpop                    = false;
 	bool                   gen_best                        = false;
-	char*                  resname                         = NULL; // by default will be "docking", dynamically created
+	char*                  resname                         = NULL; // by default will be ligand file basename
 	float                  qasp                            = 0.01097f;
 	float                  rmsd_tolerance                  = 2.0; // 2 Angstroem
 	float                  adam_beta1                      = 0.9f;

--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -69,6 +69,7 @@ typedef struct _Gridinfo
 	int    num_of_atypes;
 	int    num_of_map_atypes;
 	double origo_real_xyz [3];
+	bool   info_read      = false; // so we don't have to continue reading the same information over and over again
 } Gridinfo;
 
 struct Map

--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -57,7 +57,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //The other parameters are the type index, z, y and x coordinates of the grid point.
 
 // Struct containing all the important information coming from .gpf and .xyz files.
-typedef struct
+typedef struct _Gridinfo
 {
 	char*  grid_file_path = NULL; // Added to store the full path of the grid file
 	char*  receptor_name  = NULL;

--- a/host/inc/processresult.h
+++ b/host/inc/processresult.h
@@ -39,6 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 typedef struct
 {
+	float      genotype[GENOTYPE_LENGTH_IN_GLOBMEM];
 	Liganddata reslig_realcoord;
 	float      interE;
 	float      interflexE;

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -236,7 +236,7 @@ int preparse_dpf(
 						argstr[strlen(argstr)-4] = '\0'; // get rid of .map extension
 						typestr=strchr(argstr+strlen(argstr)-4,'.')+1; // 4 chars for atom type
 						if(mtype_nr>=ltype_nr){
-							printf("\nError: More map files specified than atom types at %s:%u (ligand types need to be specified before maps).\n",tempstr,dpf_filename,line_count);
+							printf("\nError: More map files specified than atom types at %s:%u (ligand types need to be specified before maps).\n",dpf_filename,line_count);
 							return 1;
 						}
 						if(strcmp(typestr,ltypes[mtype_nr])){ // derived type
@@ -317,7 +317,7 @@ int preparse_dpf(
 						break;
 				case DPF_RUNS: // set number of runs
 				case DPF_GALS: // actually run a search
-						sscanf(line.c_str(),"%*s %ld",&tempint);
+						sscanf(line.c_str(),"%*s %d",&tempint);
 						if ((tempint >= 1) && (tempint <= MAX_NUM_OF_RUNS))
 							mypars->num_of_runs = (int) tempint;
 						else
@@ -370,7 +370,7 @@ int preparse_dpf(
 						}
 						break;
 				case DPF_INTELEC: // calculate ES energy (needs not be "off")
-						sscanf(line.c_str(),"%*s %255s",&argstr);
+						sscanf(line.c_str(),"%*s %255s",argstr);
 						if(stricmp(argstr,"off")==0){
 							printf("\nError: \"Off\" is not supported as <%s> parameter at %s:%u.\n",tempstr,dpf_filename,line_count);
 							return 1;
@@ -386,7 +386,7 @@ int preparse_dpf(
 						break;
 				case DPF_SEED: // random number seed
 						m=0; n=0; i=0;
-						if(sscanf(line.c_str(),"%*s %ld %ld",&m, &n, &i)>0){ // one or more numbers
+						if(sscanf(line.c_str(),"%*s %d %d %d",&m, &n, &i)>0){ // one or more numbers
 							mypars->seed[0]=m; mypars->seed[1]=n; mypars->seed[2]=i;
 						} else
 							printf("Warning: Only numerical values currently supported for <%s> at %s:%u.\n",tempstr,dpf_filename,line_count);
@@ -399,21 +399,21 @@ int preparse_dpf(
 							printf("Warning: value of <%s> at %s:%u ignored. Value must be greater than 0.\n",tempstr,dpf_filename,line_count);
 						break;
 				case GA_pop_size: // population size
-						sscanf(line.c_str(),"%*s %ld",&tempint);
+						sscanf(line.c_str(),"%*s %d",&tempint);
 						if ((tempint >= 2) && (tempint <= MAX_POPSIZE))
 							mypars->pop_size = (unsigned long) (tempint);
 						else
 							printf("Warning: value of <%s> at %s:%u ignored. Value must be an integer between 2 and %d.\n",tempstr,dpf_filename,line_count,MAX_POPSIZE);
 						break;
 				case GA_num_generations: // number of generations
-						sscanf(line.c_str(),"%*s %ld",&tempint);
+						sscanf(line.c_str(),"%*s %d",&tempint);
 						if ((tempint > 0) && (tempint < 16250000))
 							mypars->num_of_generations = (unsigned long) tempint;
 						else
 							printf("Warning: value of <%s> at %s:%u ignored. Value must be between 0 and 16250000.\n",tempstr,dpf_filename,line_count);
 						break;
 				case GA_num_evals: // number of evals
-						sscanf(line.c_str(),"%*s %ld",&tempint);
+						sscanf(line.c_str(),"%*s %d",&tempint);
 						if ((tempint > 0) && (tempint < 260000000)){
 							mypars->num_of_energy_evals = (unsigned long) tempint;
 							mypars->nev_provided = true;
@@ -437,7 +437,7 @@ int preparse_dpf(
 							printf("Warning: value of <%s> at %s:%u ignored. Value must be a float between 0 and 1.\n",tempstr,dpf_filename,line_count);
 						break;
 				case SW_max_its: // local search iterations
-						sscanf(line.c_str(),"%*s %ld",&tempint);
+						sscanf(line.c_str(),"%*s %d",&tempint);
 						if ((tempint > 0) && (tempint < 262144))
 							mypars->max_num_of_iters = (unsigned long) tempint;
 						else
@@ -445,7 +445,7 @@ int preparse_dpf(
 						break;
 				case SW_max_succ: // cons. success limit
 				case SW_max_fail: // cons. failure limit
-						sscanf(line.c_str(),"%*s %ld",&tempint);
+						sscanf(line.c_str(),"%*s %d",&tempint);
 						if ((tempint > 0) && (tempint < 256))
 							mypars->cons_limit = (unsigned long) (tempint);
 						else
@@ -459,7 +459,7 @@ int preparse_dpf(
 							printf("Warning: value of <%s> at %s:%u ignored. Value must be a float between 0 and 1.\n",tempstr,dpf_filename,line_count);
 						break;
 				case DPF_UNBOUND_MODEL: // unbound model (bound|extended|compact)
-						sscanf(line.c_str(),"%*s %255s",&argstr);
+						sscanf(line.c_str(),"%*s %255s",argstr);
 						if(stricmp(argstr,"bound")==0){
 							mypars->unbound_model = 0;
 							mypars->coeffs = unbound_models[mypars->unbound_model];
@@ -474,7 +474,7 @@ int preparse_dpf(
 						}
 						break;
 				case DPF_COMMENT: // we use comments to allow specifying AD-GPU command lines
-						sscanf(line.c_str(),"%*s %255s %255s",&tempstr,&argstr);
+						sscanf(line.c_str(),"%*s %255s %255s",tempstr,argstr);
 						if(tempstr[0]=='-'){ // potential command line argument
 							i=2; // one command line argument to be parsed
 							args[0]=tempstr;
@@ -645,6 +645,7 @@ int get_filelist(
 			filelist.mypars[i].resname = strdup(filelist.resnames[i].c_str());
 		}
 	}
+	filelist.preload_maps&=filelist.used;
 
 	return 0;
 }
@@ -742,7 +743,7 @@ int get_commandpars(
 // the data in the same format as it is required for writing it to algorithm defined registers.
 {
 	int   i;
-	long  tempint;
+	int   tempint;
 	float tempfloat;
 	int   arg_recognized = 0;
 	int   arg_set = 1;
@@ -772,7 +773,7 @@ int get_commandpars(
 		if (strcmp("-nev", argv[i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv[i+1], "%ld", &tempint);
+			sscanf(argv[i+1], "%d", &tempint);
 
 			if ((tempint > 0) && (tempint < 260000000)){
 				mypars->num_of_energy_evals = (unsigned long) tempint;
@@ -792,7 +793,7 @@ int get_commandpars(
 		if (strcmp("-ngen", argv[i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv[i+1], "%ld", &tempint);
+			sscanf(argv[i+1], "%d", &tempint);
 
 			if ((tempint > 0) && (tempint < 16250000))
 				mypars->num_of_generations = (unsigned long) tempint;
@@ -804,7 +805,7 @@ int get_commandpars(
 		if (strcmp("-initswgens", argv[i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv[i+1], "%ld", &tempint);
+			sscanf(argv[i+1], "%d", &tempint);
 
 			if ((tempint >= 0) && (tempint <= 16250000))
 				mypars->initial_sw_generations = (unsigned long) tempint;
@@ -817,7 +818,7 @@ int get_commandpars(
 		if (strcmp("-heuristics", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if (tempint == 0)
 				mypars->use_heuristics = false;
@@ -830,7 +831,7 @@ int get_commandpars(
 		if (strcmp("-heurmax", argv[i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv[i+1], "%ld", &tempint);
+			sscanf(argv[i+1], "%d", &tempint);
 
 			if ((tempint > 0) && (tempint < 16250000))
 				mypars->heuristics_max = (unsigned long) tempint;
@@ -1016,7 +1017,7 @@ int get_commandpars(
 		if (strcmp("-cslim", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if ((tempint > 0) && (tempint < 256))
 				mypars->cons_limit = (unsigned long) (tempint);
@@ -1029,7 +1030,7 @@ int get_commandpars(
 		if (strcmp("-lsit", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if ((tempint > 0) && (tempint < 262144))
 				mypars->max_num_of_iters = (unsigned long) tempint;
@@ -1042,7 +1043,7 @@ int get_commandpars(
 		if (strcmp("-psize", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if ((tempint >= 2) && (tempint <= MAX_POPSIZE))
 				mypars->pop_size = (unsigned long) (tempint);
@@ -1055,7 +1056,7 @@ int get_commandpars(
 		if (strcmp("-pload", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if (tempint == 0)
 				mypars->initpop_gen_or_loadfile = false;
@@ -1068,7 +1069,7 @@ int get_commandpars(
 		if (strcmp("-npdb", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if ((tempint < 0) || (tempint > MAX_POPSIZE))
 				printf("Warning: value of -npdb argument ignored. Value must be an integer between 0 and %d.\n", MAX_POPSIZE);
@@ -1149,7 +1150,7 @@ int get_commandpars(
 			arg_set = 0;
 			if(!late_call){
 				arg_set = 1;
-				sscanf(argv [i+1], "%u", &tempint);
+				sscanf(argv [i+1], "%d", &tempint);
 				if ((tempint >= 1) && (tempint <= 65536)){
 					mypars->devnum = (unsigned long) tempint-1;
 				} else printf("Warning: value of -devnum argument ignored. Value must be an integer between 1 and 65536.\n");
@@ -1173,7 +1174,7 @@ int get_commandpars(
 		if (strcmp("-autostop", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if (tempint == 0)
 				mypars->autostop = 0;
@@ -1187,7 +1188,7 @@ int get_commandpars(
 		if (strcmp("-asfreq", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 			if ((tempint >= 1) && (tempint <= 100))
 				mypars->as_frequency = (unsigned int) tempint;
 			else
@@ -1230,7 +1231,7 @@ int get_commandpars(
 		if (strcmp("-nrun", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if ((tempint >= 1) && (tempint <= MAX_NUM_OF_RUNS))
 				mypars->num_of_runs = (int) tempint;
@@ -1243,7 +1244,7 @@ int get_commandpars(
 		if (strcmp("-rlige", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if (tempint == 0)
 				mypars->reflig_en_required = false;
@@ -1266,7 +1267,7 @@ int get_commandpars(
 		if (strcmp("-hsym", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if (tempint == 0)
 				mypars->handle_symmetry = false;
@@ -1279,7 +1280,7 @@ int get_commandpars(
 		if (strcmp("-gfpop", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if (tempint == 0)
 				mypars->gen_finalpop = false;
@@ -1292,7 +1293,7 @@ int get_commandpars(
 		if (strcmp("-gbest", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if (tempint == 0)
 				mypars->gen_best = false;
@@ -1313,7 +1314,7 @@ int get_commandpars(
 		if (strcmp("-modqp", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 
 			if (tempint == 0)
 				mypars->qasp = 0.01097f; // original AutoDock QASP parameter
@@ -1340,7 +1341,7 @@ int get_commandpars(
 		if (strcmp("-xmloutput", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%ld", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 			
 			if (tempint == 0)
 				mypars->output_xml = false;
@@ -1374,7 +1375,7 @@ int get_commandpars(
 		mypars->gen_pdbs = 1;
 	}
 	
-	return arg_recognized + arg_set<<1;
+	return arg_recognized + (arg_set<<1);
 }
 
 void gen_initpop_and_reflig(

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -954,6 +954,7 @@ int get_commandpars(
 				printf("Error: Value of -lsmet must be a valid string: \"sw\", \"sd\", \"fire\", \"ad\", or \"adam\".\n");
 				exit(-1);
 			}
+			
 			free(temp);
 		}
 

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -181,7 +181,7 @@ int preparse_dpf(
 		int m, n;
 		char typeA[4], typeB[4];
 		filelist.max_len = 256;
-		bool found;
+		bool new_device = false; // indicate if current mypars has a new device requested
 		while(std::getline(file, line)) {
 			line_count++;
 			trim(line); // Remove leading and trailing whitespace
@@ -344,6 +344,7 @@ int preparse_dpf(
 								mypars->resname[len]='\0';
 							} else mypars->resname = strdup("docking"); // Fallback to old default
 							filelist.resnames.push_back(mypars->resname);
+							if(new_device) mypars->devices_requested++;
 							// Before pushing parameters and grids back make sure
 							// the filename pointers are unique
 							if(filelist.mypars.size()>0){ // mypars and mygrids have same size
@@ -484,14 +485,12 @@ int preparse_dpf(
 							}
 							// count GPUs in case we set a different one
 							if(strcmp(tempstr,"-devnum")==0){
-								found=false;
-								for(i=0; (i<filelist.mypars.size())&&!found; i++){
+								new_device=false;
+								for(i=0; (i<filelist.mypars.size())&&!new_device; i++){
 									if(mypars->devnum==filelist.mypars[i].devnum){
-										found=true;
+										new_device=true;
 									}
 								}
-								if(!found && (filelist.mypars.size()>0))
-									mypars->devices_requested++;
 							}
 						}
 						break;

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -826,16 +826,16 @@ int get_commandpars(
 		}
 		// ----------------------------------
 
-		// Argument: initial sw number of generations. Must be a positive integer.
+		// Argument: Upper limit for heuristics that's reached asymptotically
 		if (strcmp("-heurmax", argv[i]) == 0)
 		{
 			arg_recognized = 1;
 			sscanf(argv[i+1], "%d", &tempint);
 
-			if ((tempint > 0) && (tempint < 16250000))
+			if ((tempint > 0) && (tempint <= 1625000000))
 				mypars->heuristics_max = (unsigned long) tempint;
 			else
-				printf("Warning: value of -heurmax argument ignored. Value must be between 0 and 16250000.\n");
+				printf("Warning: value of -heurmax argument ignored. Value must be between 1 and 1625000000.\n");
 		}
 
 		// Argument: maximal delta movement during mutation. Must be an integer between 1 and 16.

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char* argv[])
 		if (strcmp("-devnum", argv [i]) == 0)
 		{
 			unsigned int tempint;
-			sscanf(argv [i+1], "%u", &tempint);
+			sscanf(argv [i+1], "%d", &tempint);
 			if ((tempint >= 1) && (tempint <= 65536))
 				devnum = (unsigned long) tempint-1;
 			else
@@ -169,9 +169,9 @@ int main(int argc, char* argv[])
 	{
 		int t_id = 0;
 #endif
-		Dockpars   mypars;// = initial_pars;
+		Dockpars   mypars = initial_pars;
 		Liganddata myligand_init;
-		Gridinfo   mygrid;// = initial_grid;
+		Gridinfo   mygrid = initial_grid;
 		Liganddata myxrayligand;
 		std::vector<float> floatgrids;
 		SimulationState sim_state;
@@ -222,7 +222,7 @@ int main(int argc, char* argv[])
 				#pragma omp critical
 #endif
 				{
-					if(filelist.used && filelist.preload_maps && filelist.load_maps_gpu){
+					if(filelist.preload_maps && filelist.load_maps_gpu){
 						int size_of_one_map = 4*mygrid.size_xyz[0]*mygrid.size_xyz[1]*mygrid.size_xyz[2];
 						for (int t=0; t < all_maps.size(); t++){
 							copy_map_to_gpu(tData[dev_nr],all_maps,t,size_of_one_map);

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -544,29 +544,29 @@ parameters argc and argv:
 
 	unsigned long min_as_evals = 0; // no minimum w/o heuristics
 	if(mypars->use_heuristics){
-		printf("Using heuristics: ");
-		char newmethod[LS_METHOD_STRING_LEN];
 		unsigned long heur_evals;
 		unsigned long nev=mypars->num_of_energy_evals;
-		if(myligand_init->num_of_rotbonds<4){ // use Solis-Wets
-			strcpy(newmethod,"sw");
+		if(strcmp(mypars->ls_method,"sw")==0){
 //			heur_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 3.5));
 			heur_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 4.0));
-		} else{ // use ADAdelta
-			strcpy(newmethod,"ad");
+		} else{
+			if(strcmp(mypars->ls_method,"ad")==0){
 //			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.4 * myligand_init->num_of_rotbonds + 7.0));
 //			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.5 * myligand_init->num_of_rotbonds + 6.0));
 			heur_evals = (unsigned long)ceil(64000 * pow(2.0, (0.5 - 0.2 * myligand_init->num_of_rotbonds/(20.0f + myligand_init->num_of_rotbonds)) * myligand_init->num_of_rotbonds));
+			} else{
+				printf("\nError: LS method \"%s\" is not supported by heuristics.\n       Please choose Solis-Wets (sw), Adadelta (ad),\n       or switch off the heuristics.\n",mypars->ls_method);
+				exit(-1);
+			}
 		}
 		if(heur_evals<500000) heur_evals=500000;
 		heur_evals *= 50.0f/mypars->num_of_runs;
-		strcpy(mypars->ls_method,newmethod);
 		// e*hm/(hm+e) = 0.95*e => hm/(hm+e) = 0.95
 		// => 0.95*hm + 0.95*e = hm => 0.95*e = 0.05 * hm
 		// => e = 1/19*hm
 		// at hm = 50 M => e0 = 2.63 M where e becomes less than 95% (about 11 torsions)
 		mypars->num_of_energy_evals = (unsigned long)ceil(heur_evals*(float)mypars->heuristics_max/(mypars->heuristics_max+heur_evals));
-		printf("-lsmet %s -nev %lu\n",newmethod,mypars->num_of_energy_evals);
+		printf("Using heuristics: (capped) number of evaluations set to %lu\n",mypars->num_of_energy_evals);
 		if (mypars->nev_provided && (mypars->num_of_energy_evals>nev)){
 			printf("Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
 			mypars->num_of_energy_evals = nev;

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -655,15 +655,15 @@ parameters argc and argv:
 			// Kernel3
 			kernel3_gxsize = blocksPerGridForEachLSEntity;
 			kernel3_lxsize = threadsPerBlock;
-  			#ifdef DOCK_DEBUG
-	  		printf("%-25s %10s %8u %10s %4u\n", "K_LS_SOLISWETS", "gSize: ", kernel3_gxsize, "lSize: ", kernel3_lxsize); fflush(stdout);
-  			#endif
+			#ifdef DOCK_DEBUG
+			printf("%-25s %10s %8u %10s %4u\n", "K_LS_SOLISWETS", "gSize: ", kernel3_gxsize, "lSize: ", kernel3_lxsize); fflush(stdout);
+			#endif
 			// End of Kernel3
 		}
 		if (strcmp(mypars->ls_method, "sd") == 0) {
 			// Kernel5
-  			kernel5_gxsize = blocksPerGridForEachGradMinimizerEntity;
-  			kernel5_lxsize = threadsPerBlock;
+			kernel5_gxsize = blocksPerGridForEachGradMinimizerEntity;
+			kernel5_lxsize = threadsPerBlock;
 			#ifdef DOCK_DEBUG
 			printf("%-25s %10s %8u %10s %4u\n", "K_LS_GRAD_SDESCENT", "gSize: ", kernel5_gxsize, "lSize: ", kernel5_lxsize); fflush(stdout);
 			#endif
@@ -671,8 +671,8 @@ parameters argc and argv:
 		}
 		if (strcmp(mypars->ls_method, "fire") == 0) {
 			// Kernel6
-  			kernel6_gxsize = blocksPerGridForEachGradMinimizerEntity;
-  			kernel6_lxsize = threadsPerBlock;
+			kernel6_gxsize = blocksPerGridForEachGradMinimizerEntity;
+			kernel6_lxsize = threadsPerBlock;
 			#ifdef DOCK_DEBUG
 			printf("%-25s %10s %8u %10s %4u\n", "K_LS_GRAD_FIRE", "gSize: ", kernel6_gxsize, "lSize: ", kernel6_lxsize); fflush(stdout);
 			#endif

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -555,9 +555,9 @@ parameters argc and argv:
 		// => e = 1/19*hm
 		// at hm = 50 M => e0 = 2.63 M where e becomes less than 95% (about 11 torsions)
 		mypars->num_of_energy_evals = (unsigned long)ceil(heur_evals*(float)mypars->heuristics_max/(mypars->heuristics_max+heur_evals));
-		printf("-lsmet %s -nev %u\n",newmethod,mypars->num_of_energy_evals);
+		printf("-lsmet %s -nev %lu\n",newmethod,mypars->num_of_energy_evals);
 		if (mypars->nev_provided && (mypars->num_of_energy_evals>nev)){
-			printf("Overriding heuristics, setting number of evaluations to -nev = %u instead.\n",nev);
+			printf("Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
 			mypars->num_of_energy_evals = nev;
 			profile.capped = true;
 		}

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -110,6 +110,7 @@ void setup_gpu_for_docking(
                            GpuTempData& tData
                           )
 {
+	if(cData.devnum<-1) return; // device already setup
 	auto const t0 = std::chrono::steady_clock::now();
 
 	// Initialize CUDA
@@ -131,6 +132,7 @@ void setup_gpu_for_docking(
 		status = cudaFree(NULL); // Trick driver into creating context on current device
 	else
 		status = cudaSetDevice(cData.devnum);
+	cData.devnum=-2;
 	status = cudaDeviceSetLimit(cudaLimitPrintfFifoSize, 200000000ull);
 	RTERROR(status, "cudaDeviceSetLimit failed");
 

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -938,10 +938,10 @@ parameters argc and argv:
 			printf("*");
 			fflush(stdout);
 		}
+		printf("\n");
 	}
 
 	auto const t3 = std::chrono::steady_clock::now();
-	printf("\nDocking time %fs\n", elapsed_seconds(t2, t3));
 
 	// ===============================================================================
 	// Modification based on:
@@ -955,8 +955,7 @@ parameters argc and argv:
 
 	// Final autostop statistics output
 	if (mypars->autostop) autostop.output_final_stddev(generation_cnt, sim_state.cpu_energies.data(), total_evals);
-
-	printf("\n");
+	printf("\nDocking time %fs\n", elapsed_seconds(t2, t3));
 #if defined (DOCK_DEBUG)
 	for (int cnt_pop=0;cnt_pop<size_populations/sizeof(float);cnt_pop++)
 		printf("total_num_pop: %u, cpu_final_populations[%u]: %f\n",(unsigned int)(size_populations/sizeof(float)),cnt_pop,cpu_final_populations[cnt_pop]);

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -537,20 +537,24 @@ parameters argc and argv:
 		//blocksPerGridForEachGradMinimizerEntity = mypars->num_of_runs;
 	}
 
-	// Adjust ls_method and num_of_energy_evals based on heuristics
+	unsigned long min_as_evals = 0; // no minimum w/o heuristics
 	if(mypars->use_heuristics){
 		printf("Using heuristics: ");
 		char newmethod[LS_METHOD_STRING_LEN];
 		unsigned long heur_evals;
 		unsigned long nev=mypars->num_of_energy_evals;
-		if(myligand_init->num_of_rotbonds<8){ // use Solis-Wets
+		if(myligand_init->num_of_rotbonds<4){ // use Solis-Wets
 			strcpy(newmethod,"sw");
 //			heur_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 3.5));
 			heur_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 4.0));
 		} else{ // use ADAdelta
 			strcpy(newmethod,"ad");
-			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.4 * myligand_init->num_of_rotbonds + 7.0));
+//			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.4 * myligand_init->num_of_rotbonds + 7.0));
+//			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.5 * myligand_init->num_of_rotbonds + 6.0));
+			heur_evals = (unsigned long)ceil(64000 * pow(2.0, (0.5 - 0.2 * myligand_init->num_of_rotbonds/(20.0f + myligand_init->num_of_rotbonds)) * myligand_init->num_of_rotbonds));
 		}
+		if(heur_evals<500000) heur_evals=500000;
+		heur_evals *= 50.0f/mypars->num_of_runs;
 		strcpy(mypars->ls_method,newmethod);
 		// e*hm/(hm+e) = 0.95*e => hm/(hm+e) = 0.95
 		// => 0.95*hm + 0.95*e = hm => 0.95*e = 0.05 * hm
@@ -562,6 +566,21 @@ parameters argc and argv:
 			printf("Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
 			mypars->num_of_energy_evals = nev;
 			profile.capped = true;
+		}
+		float cap_fraction = (float)mypars->num_of_energy_evals/heur_evals;
+		float a = 27.0/26.0; // 10% at cap_fraction of 50%
+//		float a = 12.0/11.0; // 20% at cap_fraction of 50%
+		float min_frac = a/(1+cap_fraction*cap_fraction*(a/(a-1.0f)-1.0f))+1.0f-a;
+		min_as_evals = (unsigned long)ceil(mypars->num_of_energy_evals*min_frac)*mypars->num_of_runs;
+		if(cap_fraction<0.5f){
+			printf("Warning: The set number of evals is %.2f%% of the uncapped heuristics estimate of %lu evals.\n",cap_fraction*100.0f,heur_evals);
+			printf("         This means this docking may not be able to converge. Increasing ");
+			if (mypars->nev_provided && (mypars->num_of_energy_evals>nev))
+				printf("-nev");
+			else
+				printf("-heurmax");
+			printf(" may improve\n         convergence but will also increase runtime.\n");
+			if(mypars->autostop) printf("         AutoStop will not stop before %.2f%% (%lu) of the set number of evaluations.\n",min_frac*100.0f,min_as_evals/mypars->num_of_runs);
 		}
 	}
 	
@@ -759,7 +778,8 @@ parameters argc and argv:
 				status = cudaMemcpy(sim_state.cpu_energies.data(), pMem_energies_current, size_energies, cudaMemcpyDeviceToHost);
 				RTERROR(status, "cudaMemcpy: couldn't downloaded pMem_energies_current");
 				if (autostop.check_if_satisfactory(generation_cnt, sim_state.cpu_energies.data(), total_evals))
-					break; // Exit loop
+					if (total_evals>min_as_evals)
+						break; // Exit loop when all conditions are satisfied
 			}
 		}
 		else

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -23,6 +23,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 
+// If defined, will set the maximum Cuda printf FIFO buffer to 8 GB (default: commented out)
+// This is not needed unless debugging Cuda kernels via printf statements
+// #define SET_CUDA_PRINTF_BUFFER
+
 #include <chrono>
 #include <vector>
 
@@ -133,9 +137,10 @@ void setup_gpu_for_docking(
 	else
 		status = cudaSetDevice(cData.devnum);
 	cData.devnum=-2;
+#ifdef SET_CUDA_PRINTF_BUFFER
 	status = cudaDeviceSetLimit(cudaLimitPrintfFifoSize, 200000000ull);
 	RTERROR(status, "cudaDeviceSetLimit failed");
-
+#endif
 	auto const t1 = std::chrono::steady_clock::now();
 	printf("\nCUDA Setup time %fs\n", elapsed_seconds(t0 ,t1));
 	size_t sz_interintra_const      = MAX_NUM_OF_ATOMS*sizeof(float) +

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -567,7 +567,7 @@ parameters argc and argv:
 
 	if(!floatgrids_preloaded)
 		memcopyBufferObjectToDevice(tData.command_queue,tData.pMem_fgrids,          false, cpu_floatgrids,                     size_floatgrids);
- 	memcopyBufferObjectToDevice(tData.command_queue,mem_dockpars_conformations_current, false, cpu_init_populations,               size_populations);
+	memcopyBufferObjectToDevice(tData.command_queue,mem_dockpars_conformations_current, false, cpu_init_populations,               size_populations);
 	memcopyBufferObjectToDevice(tData.command_queue,mem_gpu_evals_of_runs,              false, sim_state.cpu_evals_of_runs.data(), size_evals_of_runs);
 	memcopyBufferObjectToDevice(tData.command_queue,mem_dockpars_prng_states,           false, cpu_prng_seeds,                     size_prng_seeds);
 

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -627,29 +627,29 @@ parameters argc and argv:
 	
 	unsigned long min_as_evals = 0; // no minimum w/o heuristics
 	if(mypars->use_heuristics){
-		printf("Using heuristics: ");
-		char newmethod[LS_METHOD_STRING_LEN];
 		unsigned long heur_evals;
 		unsigned long nev=mypars->num_of_energy_evals;
-		if(myligand_init->num_of_rotbonds<4){ // use Solis-Wets
-			strcpy(newmethod,"sw");
+		if(strcmp(mypars->ls_method,"sw")==0){
 //			heur_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 3.5));
 			heur_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 4.0));
-		} else{ // use ADAdelta
-			strcpy(newmethod,"ad");
+		} else{
+			if(strcmp(mypars->ls_method,"ad")==0){
 //			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.4 * myligand_init->num_of_rotbonds + 7.0));
 //			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.5 * myligand_init->num_of_rotbonds + 6.0));
 			heur_evals = (unsigned long)ceil(64000 * pow(2.0, (0.5 - 0.2 * myligand_init->num_of_rotbonds/(20.0f + myligand_init->num_of_rotbonds)) * myligand_init->num_of_rotbonds));
+			} else{
+				printf("\nError: LS method \"%s\" is not supported by heuristics.\n       Please choose Solis-Wets (sw), Adadelta (ad),\n       or switch off the heuristics.\n",mypars->ls_method);
+				exit(-1);
+			}
 		}
 		if(heur_evals<500000) heur_evals=500000;
 		heur_evals *= 50.0f/mypars->num_of_runs;
-		strcpy(mypars->ls_method,newmethod);
 		// e*hm/(hm+e) = 0.95*e => hm/(hm+e) = 0.95
 		// => 0.95*hm + 0.95*e = hm => 0.95*e = 0.05 * hm
 		// => e = 1/19*hm
 		// at hm = 50 M => e0 = 2.63 M where e becomes less than 95% (about 11 torsions)
 		mypars->num_of_energy_evals = (unsigned long)ceil(heur_evals*(float)mypars->heuristics_max/(mypars->heuristics_max+heur_evals));
-		printf("-lsmet %s -nev %lu\n",newmethod,mypars->num_of_energy_evals);
+		printf("Using heuristics: (capped) number of evaluations set to %lu\n",mypars->num_of_energy_evals);
 		if (mypars->nev_provided && (mypars->num_of_energy_evals>nev)){
 			printf("Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
 			mypars->num_of_energy_evals = nev;

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -625,19 +625,24 @@ parameters argc and argv:
 		//blocksPerGridForEachGradMinimizerEntity = mypars->num_of_runs;
 	}
 	
+	unsigned long min_as_evals = 0; // no minimum w/o heuristics
 	if(mypars->use_heuristics){
 		printf("Using heuristics: ");
 		char newmethod[LS_METHOD_STRING_LEN];
 		unsigned long heur_evals;
 		unsigned long nev=mypars->num_of_energy_evals;
-		if(myligand_init->num_of_rotbonds<8){ // use Solis-Wets
+		if(myligand_init->num_of_rotbonds<4){ // use Solis-Wets
 			strcpy(newmethod,"sw");
 //			heur_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 3.5));
 			heur_evals = (unsigned long)ceil(1000 * pow(2.0,1.3 * myligand_init->num_of_rotbonds + 4.0));
 		} else{ // use ADAdelta
 			strcpy(newmethod,"ad");
-			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.4 * myligand_init->num_of_rotbonds + 7.0));
+//			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.4 * myligand_init->num_of_rotbonds + 7.0));
+//			heur_evals = (unsigned long)ceil(1000 * pow(2.0,0.5 * myligand_init->num_of_rotbonds + 6.0));
+			heur_evals = (unsigned long)ceil(64000 * pow(2.0, (0.5 - 0.2 * myligand_init->num_of_rotbonds/(20.0f + myligand_init->num_of_rotbonds)) * myligand_init->num_of_rotbonds));
 		}
+		if(heur_evals<500000) heur_evals=500000;
+		heur_evals *= 50.0f/mypars->num_of_runs;
 		strcpy(mypars->ls_method,newmethod);
 		// e*hm/(hm+e) = 0.95*e => hm/(hm+e) = 0.95
 		// => 0.95*hm + 0.95*e = hm => 0.95*e = 0.05 * hm
@@ -649,6 +654,21 @@ parameters argc and argv:
 			printf("Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
 			mypars->num_of_energy_evals = nev;
 			profile.capped = true;
+		}
+		float cap_fraction = (float)mypars->num_of_energy_evals/heur_evals;
+		float a = 27.0/26.0; // 10% at cap_fraction of 50%
+//		float a = 12.0/11.0; // 20% at cap_fraction of 50%
+		float min_frac = a/(1+cap_fraction*cap_fraction*(a/(a-1.0f)-1.0f))+1.0f-a;
+		min_as_evals = (unsigned long)ceil(mypars->num_of_energy_evals*min_frac)*mypars->num_of_runs;
+		if(cap_fraction<0.5f){
+			printf("Warning: The set number of evals is %.2f%% of the uncapped heuristics estimate of %lu evals.\n",cap_fraction*100.0f,heur_evals);
+			printf("         This means this docking may not be able to converge. Increasing ");
+			if (mypars->nev_provided && (mypars->num_of_energy_evals>nev))
+				printf("-nev");
+			else
+				printf("-heurmax");
+			printf(" may improve\n         convergence but will also increase runtime.\n");
+			if(mypars->autostop) printf("         AutoStop will not stop before %.2f%% (%lu) of the set number of evaluations.\n",min_frac*100.0f,min_as_evals/mypars->num_of_runs);
 		}
 	}
 	
@@ -1065,7 +1085,8 @@ parameters argc and argv:
 				else
 					memcopyBufferObjectFromDevice(tData.command_queue,sim_state.cpu_energies.data(),mem_dockpars_energies_next,size_energies);
 				if (autostop.check_if_satisfactory(generation_cnt, sim_state.cpu_energies.data(), total_evals))
-					break; // Exit loop
+					if (total_evals>min_as_evals)
+						break; // Exit loop when all conditions are satisfied
 			}
 		}
 		else

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -641,9 +641,9 @@ parameters argc and argv:
 		// => e = 1/19*hm
 		// at hm = 50 M => e0 = 2.63 M where e becomes less than 95% (about 11 torsions)
 		mypars->num_of_energy_evals = (unsigned long)ceil(heur_evals*(float)mypars->heuristics_max/(mypars->heuristics_max+heur_evals));
-		printf("-lsmet %s -nev %u\n",newmethod,mypars->num_of_energy_evals);
+		printf("-lsmet %s -nev %lu\n",newmethod,mypars->num_of_energy_evals);
 		if (mypars->nev_provided && (mypars->num_of_energy_evals>nev)){
-			printf("Overriding heuristics, setting number of evaluations to -nev = %u instead.\n",nev);
+			printf("Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
 			mypars->num_of_energy_evals = nev;
 			profile.capped = true;
 		}

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -128,6 +128,7 @@ void setup_gpu_for_docking(
                            GpuTempData& tData
                           )
 {
+	if(cData.devnum<-1) return; // device already setup
 // =======================================================================
 // OpenCL Host Setup
 // =======================================================================
@@ -231,6 +232,8 @@ void setup_gpu_for_docking(
 	char* device_name = (char*) malloc(dev_name_size);
 	clGetDeviceInfo(device_ids[cData.devnum], CL_DEVICE_NAME, dev_name_size, device_name, NULL);
 	printf("OpenCL device:                           %s\n",device_name);
+	cData.devnum=-2;
+
 	free(device_name);
 
 	// Create context from first platform
@@ -239,7 +242,7 @@ void setup_gpu_for_docking(
 	// Create command queue for first device
 	if (createCommandQueue(tData.context,device_id,&tData.command_queue) != 0) exit(-1);
 
-	// Create program from source 
+	// Create program from source
 #ifdef _WIN32
 	if (ImportSource(filename, name_k1, &device_id, tData.context, options_program, &tData.kernel1) != 0) exit(-1);
 	if (ImportSource(filename, name_k2, &device_id, tData.context, options_program, &tData.kernel2) != 0) exit(-1);

--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -30,6 +30,8 @@ int get_gridinfo(
                        Gridinfo* mygrid
                 )
 {
+	if(mygrid->info_read) return 0; // already succesfully read this grid's information
+
 	FILE*  fp;
 	char   tempstr [256];
 	int    gpoints_even[3];
@@ -145,6 +147,7 @@ int get_gridinfo(
 	mygrid->origo_real_xyz[2] = center[2] - (((double) gpoints_even[2])*0.5*(mygrid->spacing));
 
 	fclose(fp);
+	mygrid->info_read = true;
 
 	return 0;
 }

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -202,7 +202,10 @@ void write_basic_info_dlg(
 	}
 	fprintf(fp, "Grid fld file:                             %s\n\n", mypars->fldfile);
 
-	fprintf(fp, "Random seed:                               %u\n", mypars->seed);
+	fprintf(fp, "Random seed:                               %u", mypars->seed[0]);
+	if(mypars->seed[1]>0) fprintf(fp,", %u",mypars->seed[1]);
+	if(mypars->seed[2]>0) fprintf(fp,", %u",mypars->seed[2]);
+	fprintf(fp, "\n");
 	fprintf(fp, "Number of runs:                            %lu\n", mypars->num_of_runs);
 	fprintf(fp, "Number of energy evaluations:              %ld\n", mypars->num_of_energy_evals);
 	fprintf(fp, "Number of generations:                     %ld\n", mypars->num_of_generations);

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -414,10 +414,10 @@ void make_resfiles(
 		fprintf(fp, "     STATE OF FINAL POPULATION     \n");
 		fprintf(fp, "===================================\n\n");
 
-		fprintf(fp, " Entity |      dx [A]      |      dy [A]      |      dz [A]      |     phi []      |    theta []     | alpha_genrot [] |");
+		fprintf(fp, " Entity |      dx [A]      |      dy [A]      |      dz [A]      |      phi []      |     theta []     |  alpha_genrot [] |");
 		for (i=0; i<ligand_from_pdb->num_of_rotbonds; i++)
-			fprintf(fp, " alpha_rotb%2d [] |", i);
-		fprintf(fp, " intramolecular energy | intermolecular energy | total energy calculated by CPU / calculated by GPU / difference | RMSD [A] | \n");
+			fprintf(fp, "  alpha_rotb%2d [] |", i);
+		fprintf(fp, " intramolecular energy | intermolecular energy |     total energy calculated by CPU / calculated by GPU / difference    | RMSD [A] | \n");
 
 		fprintf(fp, "--------+------------------+------------------+------------------+------------------+------------------+------------------+");
 		for (i=0; i<ligand_from_pdb->num_of_rotbonds; i++)

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -381,7 +381,8 @@ void make_resfiles(
 
 		// copying best result to output parameter
 		if (i == 0) // assuming this is the best one (final_population is arranged), however, the
-		{           // arrangement was made according to the unaccurate values calculated by FPGA
+		{           // arrangement was made according to the inaccurate values calculated by FPGA
+			memcpy(best_result->genotype, final_population+i*GENOTYPE_LENGTH_IN_GLOBMEM, ACTUAL_GENOTYPE_LENGTH*sizeof(float));
 			best_result->interE = accurate_interE [i];
 			best_result->interflexE = accurate_interflexE [i];
 			best_result->intraE = accurate_intraE [i];
@@ -607,10 +608,11 @@ void clusanal_gendlg(
                            double        exec_time,
                            double        idle_time
                     )
-// The function performs ranked cluster analisys similar to that of AutoDock and creates a file with report_file_name name, the result
+// The function performs ranked cluster analysis similar to that of AutoDock and creates a file with report_file_name name, the result
 // will be written to it.
 {
 	int i, j, atom_cnt;
+	int root_atom = 0;
 	Ligandresult temp_ligres;
 	int num_of_clusters;
 	int current_clust_center;
@@ -761,6 +763,8 @@ void clusanal_gendlg(
 				else
 					if (strncmp("ROOT", tempstr, 4) == 0)
 					{
+						if(l==0) // only use ligand root
+							root_atom = atom_cnt;
 						fprintf(fp, "DOCKED: USER                              x       y       z     vdW  Elec       q    Type\n");
 						fprintf(fp, "DOCKED: USER                           _______ _______ _______ _____ _____    ______ ____\n");
 						fprintf(fp, "DOCKED: %s", tempstr);
@@ -935,6 +939,49 @@ void clusanal_gendlg(
 		fp_xml = fopen(xml_file_name, "w");
 
 		fprintf(fp_xml, "<?xml version=\"1.0\" ?>\n");
+		fprintf(fp_xml, "<autodock_gpu>\n");
+		fprintf(fp_xml, "\t<version>%s</version>\n",VERSION);
+		if((*argc)>1){
+			fprintf(fp_xml, "\t<arguments>");
+			for(i=1; i<(*argc); i++)
+				fprintf(fp_xml, "%s%s", (i>1)?" ":"", argv[i]);
+			fprintf(fp_xml, "</arguments>\n");
+		}
+		fprintf(fp_xml, "\t<ls_method>%s</ls_method>\n",mypars->ls_method);
+		fprintf(fp_xml, "\t<autostop>%s</autostop>\n",mypars->autostop ? "yes" : "no");
+		fprintf(fp_xml, "\t<heuristics>%s</heuristics>\n",mypars->use_heuristics ? "yes" : "no");
+		fprintf(fp_xml, "\t<run_requested>%d</run_requested>\n",mypars->num_of_runs);
+		fprintf(fp_xml, "\t<runs>\n");
+		double phi, theta;
+		for(j=0; j<num_of_runs; j++){
+			fprintf(fp_xml, "\t\t<run id=\"%d\">\n",(myresults [j]).run_number);
+			fprintf(fp_xml, "\t\t\t<seed>");
+			if(!mypars->seed[2]){
+				if(!mypars->seed[1]){
+					fprintf(fp_xml,"%d", mypars->seed[0]);
+				} else fprintf(fp_xml,"%d %d", mypars->seed[0], mypars->seed[1]);
+			} else fprintf(fp_xml,"%d %d %d", mypars->seed[0], mypars->seed[1], mypars->seed[2]);
+			fprintf(fp_xml, "</seed>\n");
+			if(mypars->dpffile)
+				fprintf(fp_xml, "\t\t\t<dpf>%s</dpf>\n",mypars->dpffile);
+			fprintf(fp_xml, "\t\t\t<free_NRG_binding>   %.2f</free_NRG_binding>\n", myresults[j].interE + myresults[j].interflexE + torsional_energy);
+			fprintf(fp_xml, "\t\t\t<final_intermol_NRG> %.2f</final_intermol_NRG>\n", myresults[j].interE + myresults[j].interflexE);
+			fprintf(fp_xml, "\t\t\t<internal_ligand_NRG>%.2f</internal_ligand_NRG>\n", myresults[j].intraE + myresults[j].intraflexE);
+			fprintf(fp_xml, "\t\t\t<torsonial_free_NRG> %.2f</torsonial_free_NRG>\n", torsional_energy);
+			fprintf(fp_xml, "\t\t\t<move>%s</move>\n", mypars->ligandfile);
+			fprintf(fp_xml, "\t\t\t<tran0>%.6f %.6f %.6f</tran0>\n", myresults[j].genotype[0]*mygrid->spacing, myresults[j].genotype[1]*mygrid->spacing, myresults[j].genotype[2]*mygrid->spacing);
+			phi = myresults[j].genotype[3]/180.0*PI;
+			theta = myresults[j].genotype[4]/180.0*PI;
+			fprintf(fp_xml, "\t\t\t<axisangle0>%.8f %.8f %.8f %.6f</axisangle0>\n", sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta), myresults[j].genotype[5]);
+			fprintf(fp_xml, "\t\t\t<ndihe>%d</ndihe>\n", myresults[j].reslig_realcoord.num_of_rotbonds);
+			fprintf(fp_xml, "\t\t\t<dihe0>");
+			for(i=0; i<myresults[j].reslig_realcoord.num_of_rotbonds; i++)
+				fprintf(fp_xml, "%s%.6f", (i>0)?" ":"", myresults[j].genotype[6+i]);
+			fprintf(fp_xml, "\n\t\t\t</dihe0>\n");
+			fprintf(fp_xml, "\t\t</run>\n");
+		}
+		fprintf(fp_xml, "\t</runs>\n");
+		fprintf(fp_xml, "</autodock_gpu>\n");
 		fprintf(fp_xml, "<result>\n");
 
 		fprintf(fp_xml, "\t<clustering_histogram>\n");
@@ -951,8 +998,8 @@ void clusanal_gendlg(
 			for (j=0; j<num_of_runs; j++)
 				if (myresults [j].clus_id == i+1)
 				{
-	            	fprintf(fp_xml, "\t\t<run rank=\"%d\" sub_rank=\"%d\" run=\"%d\" binding_energy=\"%.2lf\" cluster_rmsd=\"%.2lf\" reference_rmsd=\"%.2lf\" />\n",
-	            			(myresults [j]).clus_id, (myresults [j]).clus_subrank, (myresults [j]).run_number, myresults[j].interE + torsional_energy, (myresults [j]).rmsd_from_cluscent, (myresults [j]).rmsd_from_ref);
+					fprintf(fp_xml, "\t\t<run rank=\"%d\" sub_rank=\"%d\" run=\"%d\" binding_energy=\"%.2lf\" cluster_rmsd=\"%.2lf\" reference_rmsd=\"%.2lf\" />\n",
+					                     (myresults [j]).clus_id, (myresults [j]).clus_subrank, (myresults [j]).run_number, myresults[j].interE + myresults[j].interflexE + torsional_energy, (myresults [j]).rmsd_from_cluscent, (myresults [j]).rmsd_from_ref);
 				}
 		}
 		fprintf(fp_xml, "\t</rmsd_table>\n");

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -975,7 +975,7 @@ void process_result(
 	std::vector<Ligandresult> cpu_result_ligands(mypars->num_of_runs);
 
 	// Fill in cpu_result_ligands
-	float best_energy_of_all = 1000000000000;
+	float best_energy_of_all = 1000000000000.0;
 	for (unsigned long run_cnt=0; run_cnt < mypars->num_of_runs; run_cnt++)
 	{
 		arrange_result(sim_state.cpu_populations.data()+run_cnt*mypars->pop_size*GENOTYPE_LENGTH_IN_GLOBMEM, sim_state.cpu_energies.data()+run_cnt*mypars->pop_size, mypars->pop_size);

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -75,8 +75,10 @@ int setup(
 	//------------------------------------------------------------
 
 	if(filelist.used){
-		strcpy(mypars.fldfile, filelist.fld_files[i_file].c_str());
-		strcpy(mypars.ligandfile, filelist.ligand_files[i_file].c_str());
+		if(mypars.fldfile) free(mypars.fldfile);
+		if(mypars.ligandfile) free(mypars.ligandfile);
+		mypars.fldfile = strdup(filelist.fld_files[i_file].c_str());
+		mypars.ligandfile = strdup(filelist.ligand_files[i_file].c_str());
 	}
 
 	// Filling the filename and coeffs fields of mypars according to command line arguments
@@ -88,11 +90,6 @@ int setup(
 	// for derived atom types, and modified atom type pairs
 	// since they will be needed at ligand and grid creation
 	//------------------------------------------------------------
-	mypars.nr_deriv_atypes		= 0;    // this is to support: -derivtype C1,C2,C3=C
-	mypars.deriv_atypes		= NULL; // or even: -derivtype C1,C2,C3=C/S4=S/H5=HD
-	mypars.nr_mod_atype_pairs	= 0;    // this is to support: -modpair C1:S4,1.60,1.200,13,7
-	mypars.mod_atype_pairs		= NULL; // or even: -modpair C1:S4,1.60,1.200,13,7/C1:C3,1.20 0.025
-	mypars.cgmaps = 0; // default is 0 (use one maps for every CGx or Gx atom types, respectively)
 	for (unsigned int i=1; i<argc-1; i+=2)
 	{
 		// ----------------------------------
@@ -286,7 +283,7 @@ int setup(
 		return 1;
 	}
 
-	// Filling the atom types filed of myligand according to the grid types
+	// Filling the atom types field of myligand according to the grid types
 	if (init_liganddata(mypars.ligandfile,
 	                    mypars.flexresfile,
 	                    &myligand_init,

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -490,7 +490,7 @@ int load_all_maps(
 			strcat(tempstr, "/");
 			strcat(tempstr, mygrid->receptor_name);
 			strcat(tempstr, ".");
-			strcat(tempstr, mygrid->grid_types[t]);
+			strcat(tempstr, all_maps[t].atype.c_str());
 			strcat(tempstr, ".map");
 			fp = fopen(tempstr, "rb"); // fp = fopen(tempstr, "r");
 		}

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -369,18 +369,17 @@ int setup(
 	//------------------------------------------------------------
 	// Capturing algorithm parameters (command line args)
 	//------------------------------------------------------------
+	char* orig_resn = mypars.resname;
 	get_commandpars(&argc, argv, &(mygrid.spacing), &mypars);
 
-	if (i_file<filelist.resnames.size()){ // Overwrite resname with specified filename if specified in file list
-		if(mypars.resname) free(mypars.resname);
-		mypars.resname = (char*)malloc((filelist.max_len+1)*sizeof(char));
-		strcpy(mypars.resname, filelist.resnames[i_file].c_str());
-	} else if (filelist.used) { // otherwise add the index to existing name distinguish the files if multiple
+	// command-line specified resname with more than one file
+	if ((orig_resn!=mypars.resname) && (filelist.nfiles>1)){ // add an index to existing name distinguish the files
 		char* tmp = strdup(mypars.resname);
-		char* nrtmp = strdup(std::to_string(i_file).c_str());
+		char* nrtmp = strdup(std::to_string(i_file+1).c_str());
 		if(mypars.resname) free(mypars.resname);
-		mypars.resname = (char*)malloc((strlen(tmp)+strlen(nrtmp)+1)*sizeof(char));
+		mypars.resname = (char*)malloc((strlen(tmp)+strlen(nrtmp)+2)*sizeof(char));
 		strcpy(mypars.resname, tmp);
+		strcat(mypars.resname,"_");
 		strcat(mypars.resname, nrtmp);
 		free(tmp);
 		free(nrtmp);

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -371,14 +371,14 @@ int setup(
 	//------------------------------------------------------------
 	get_commandpars(&argc, argv, &(mygrid.spacing), &mypars);
 
-	if (filelist.resnames.size()>0){ // Overwrite resname with specified filename if specified in file list
-		free(mypars.resname);
+	if (i_file<filelist.resnames.size()){ // Overwrite resname with specified filename if specified in file list
+		if(mypars.resname) free(mypars.resname);
 		mypars.resname = (char*)malloc((filelist.max_len+1)*sizeof(char));
 		strcpy(mypars.resname, filelist.resnames[i_file].c_str());
 	} else if (filelist.used) { // otherwise add the index to existing name distinguish the files if multiple
 		char* tmp = strdup(mypars.resname);
 		char* nrtmp = strdup(std::to_string(i_file).c_str());
-		free(mypars.resname);
+		if(mypars.resname) free(mypars.resname);
 		mypars.resname = (char*)malloc((strlen(tmp)+strlen(nrtmp)+1)*sizeof(char));
 		strcpy(mypars.resname, tmp);
 		strcat(mypars.resname, nrtmp);

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -311,7 +311,6 @@ int setup(
 						got_error = true;
 					}
 					filelist.maps_are_loaded = true;
-					filelist.load_maps_gpu = true; // first thread seeing this will copy to GPU
 				}
 			}
 			// Return must be outside pragma

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -36,19 +36,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 int preload_gridsize(FileList& filelist)
 {
 	if(!filelist.used) return 0;
-	Gridinfo mygrid;
 	int gridsize=0;
 	for(unsigned int i_file=0; i_file<filelist.fld_files.size(); i_file++){
 		// Filling mygrid according to the gpf file
-		if (get_gridinfo(filelist.fld_files[i_file].c_str(), &mygrid) != 0)
+		if (get_gridinfo(filelist.fld_files[i_file].c_str(), &filelist.mygrids[i_file]) != 0)
 			{printf("\n\nError in get_gridinfo, stopped job."); return 1;}
-		int curr_size = 4*mygrid.size_xyz[0]*mygrid.size_xyz[1]*mygrid.size_xyz[2];
+		int curr_size = 4*filelist.mygrids[i_file].size_xyz[0]*filelist.mygrids[i_file].size_xyz[1]*filelist.mygrids[i_file].size_xyz[2];
 		if(curr_size>gridsize)
 			gridsize=curr_size;
 	}
-	if(mygrid.grid_file_path) free(mygrid.grid_file_path);
-	if(mygrid.receptor_name) free(mygrid.receptor_name);
-	if(mygrid.map_base_name) free(mygrid.map_base_name);
 	return gridsize;
 }
 
@@ -65,17 +61,6 @@ int setup(
           char*               argv[]
          )
 {
-	//------------------------------------------------------------
-	// Capturing names of grid parameter file and ligand pdbqt file
-	//------------------------------------------------------------
-
-	if(filelist.used){
-		if(mypars.fldfile) free(mypars.fldfile);
-		if(mypars.ligandfile) free(mypars.ligandfile);
-		mypars.fldfile = strdup(filelist.fld_files[i_file].c_str());
-		mypars.ligandfile = strdup(filelist.ligand_files[i_file].c_str());
-	}
-
 	// Filling the filename and coeffs fields of mypars according to command line arguments
 	if (get_filenames_and_ADcoeffs(&argc, argv, &mypars, filelist.used) != 0)
 		{printf("\n\nError in get_filenames_and_ADcoeffs, stopped job."); return 1;}
@@ -271,7 +256,7 @@ int setup(
 	// Processing receptor and ligand files
 	//------------------------------------------------------------
 
-	// Filling mygrid according to the gpf file
+	// Filling mygrid according to the fld file
 	if (get_gridinfo(mypars.fldfile, &mygrid) != 0)
 	{
 		printf("\n\nError in get_gridinfo, stopped job.");

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -23,11 +23,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 
-// Output for the -derivtype keyword
-// #define DERIVTYPE_INFO
-// Output for the -modpair keyword
-// #define MODPAIR_INFO
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>


### PR DESCRIPTION
This PR allows AD-GPU to read an AutoDock 4.2 type dpf input deck. It currently only supports a subset of tokens as not all of them are compatible with AD-GPU's algorithms. With this code, dpf files can be used to set command line parameters and even run an entire docking set. If multiple runs are specified in the dpf file it will perform them in addition to any runs specified with the `-filelist` feature. Command line options are able to override options set in the dpf file.

I tested on a small subset of dpf files and things are working but of course I am sure there's bugs or maybe even the occasional strange behavior lurking ...