### PR TITLE
Added device name and available memory output to Cuda.

### DIFF
--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -136,6 +136,16 @@ void setup_gpu_for_docking(
 		status = cudaFree(NULL); // Trick driver into creating context on current device
 	else
 		status = cudaSetDevice(cData.devnum);
+	// Now that we have a device, gather some information
+	size_t freemem, totalmem;
+	cudaDeviceProp props;
+	RTERROR(cudaGetDevice(&(cData.devnum)),"cudaGetDevice failed");
+	RTERROR(cudaGetDeviceProperties(&props,cData.devnum),"cudaGetDeviceProperties failed");
+	printf("Cuda device:                              %s",props.name);
+	if(gpuCount>1) printf(" (#%d / %d)",cData.devnum+1,gpuCount);
+	printf("\n");
+	RTERROR(cudaMemGetInfo(&freemem,&totalmem), "cudaGetMemInfo failed");
+	printf("Available memory on device:               %llu MB (total: %llu MB)\n",(freemem>>20),(totalmem>>20));
 	cData.devnum=-2;
 #ifdef SET_CUDA_PRINTF_BUFFER
 	status = cudaDeviceSetLimit(cudaLimitPrintfFifoSize, 200000000ull);

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -231,7 +231,9 @@ void setup_gpu_for_docking(
 	clGetDeviceInfo(device_ids[cData.devnum], CL_DEVICE_NAME, 0, NULL, &dev_name_size);
 	char* device_name = (char*) malloc(dev_name_size);
 	clGetDeviceInfo(device_ids[cData.devnum], CL_DEVICE_NAME, dev_name_size, device_name, NULL);
-	printf("OpenCL device:                           %s\n",device_name);
+	printf("OpenCL device:                           %s",device_name);
+	if(deviceCount>1) printf(" (#%d / %d)",cData.devnum+1,deviceCount);
+	printf("\n");
 	cData.devnum=-2;
 
 	free(device_name);


### PR DESCRIPTION
This PR adds device name and available memory output to Cuda. Additionally, the device number out of total number of devices when there is more than one device for both OpenCL and Cuda is displayed now as well.

I think this is good info to have (particularly in a multi-GPU environment). This code should not affect any computational bits, so a quick test to make sure it compiles properly on different machines (I tested under macOS with OpenCL and under Linux with Cuda) is likely all that's needed.