### PR TITLE
Fixed uint to int comparison warnings in OpenCL code.

### DIFF
--- a/device/auxiliary_genetic.cl
+++ b/device/auxiliary_genetic.cl
@@ -107,7 +107,7 @@ void gpu_perform_elitist_selection(
 	int entity_counter;
 	int gene_counter;
 	float best_energy;
-	uint tidx = get_local_id(0);
+	int tidx = get_local_id(0);
 
 	if (tidx < dockpars_pop_size) {
 		best_energies[tidx] = dockpars_energies_current[get_group_id(0)+tidx];

--- a/device/calcenergy.cl
+++ b/device/calcenergy.cl
@@ -190,7 +190,7 @@ void gpu_calc_energy(
 
 	// Initializing gradients (forces) 
 	// Derived from autodockdev/maps.py
-	for (uint atom_id = tidx;
+	for ( int atom_id = tidx;
 	          atom_id < dockpars_num_of_atoms;
 	          atom_id+= NUM_OF_THREADS_PER_BLOCK)
 	{
@@ -228,14 +228,14 @@ void gpu_calc_energy(
 	// ================================================
 	// CALCULATING ATOMIC POSITIONS AFTER ROTATIONS
 	// ================================================
-	for (uint rotation_counter = tidx;
+	for ( int rotation_counter = tidx;
 	          rotation_counter < dockpars_rotbondlist_length;
 	          rotation_counter+=NUM_OF_THREADS_PER_BLOCK)
 	{
 		int rotation_list_element = kerconst_rotlist->rotlist_const[rotation_counter];
 		if ((rotation_list_element & RLIST_DUMMY_MASK) == 0) // If not dummy rotation
 		{
-			uint atom_id = rotation_list_element & RLIST_ATOMID_MASK;
+			int atom_id = rotation_list_element & RLIST_ATOMID_MASK;
 			// Capturing atom coordinates
 			float4 atom_to_rotate = calc_coords[atom_id];
 			// initialize with general rotation values
@@ -293,7 +293,7 @@ void gpu_calc_energy(
 	// ================================================
 	float weights[8];
 	float cube[8];
-	for (uint atom_id = tidx;
+	for ( int atom_id = tidx;
 	          atom_id < dockpars_num_of_atoms;
 	          atom_id+= NUM_OF_THREADS_PER_BLOCK)
 	{
@@ -396,7 +396,7 @@ void gpu_calc_energy(
 	barrier(CLK_LOCAL_MEM_FENCE);
 
 	// reduction to calculate energy
-	for (uint off=NUM_OF_THREADS_PER_BLOCK>>1; off>0; off >>= 1)
+	for ( int off=NUM_OF_THREADS_PER_BLOCK>>1; off>0; off >>= 1)
 	{
 		barrier(CLK_LOCAL_MEM_FENCE);
 		if (tidx < off)
@@ -414,12 +414,12 @@ void gpu_calc_energy(
 	// ================================================
 	// CALCULATING INTRAMOLECULAR ENERGY
 	// ================================================
-	for (uint contributor_counter = tidx;
+	for ( int contributor_counter = tidx;
 	          contributor_counter < dockpars_num_of_intraE_contributors;
 	          contributor_counter +=NUM_OF_THREADS_PER_BLOCK)
 #if 0
 if (tidx == 0) {
-	for (uint contributor_counter = 0;
+	for ( int contributor_counter = 0;
 	          contributor_counter < dockpars_num_of_intraE_contributors;
 	          contributor_counter ++)
 #endif
@@ -553,7 +553,7 @@ if (tidx == 0) {
 	barrier(CLK_LOCAL_MEM_FENCE);
 
 	// reduction to calculate energy
-	for (uint off=NUM_OF_THREADS_PER_BLOCK>>1; off>0; off >>= 1)
+	for ( int off=NUM_OF_THREADS_PER_BLOCK>>1; off>0; off >>= 1)
 	{
 		barrier(CLK_LOCAL_MEM_FENCE);
 		if (tidx < off)

--- a/device/kernel1.cl
+++ b/device/kernel1.cl
@@ -78,7 +78,7 @@ gpu_calc_initpop(
 	                                   dockpars_conformations_current + GENOTYPE_LENGTH_IN_GLOBMEM*get_group_id(0),
 	                                   ACTUAL_GENOTYPE_LENGTH, 0);
 
-	uint tidx = get_local_id(0);
+	int tidx = get_local_id(0);
 	// Determining run-ID
 	if (tidx == 0) {
 		run_id = get_group_id(0) / dockpars_pop_size;

--- a/device/kernel2.cl
+++ b/device/kernel2.cl
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 __kernel void __attribute__ ((reqd_work_group_size(NUM_OF_THREADS_PER_BLOCK,1,1)))
 gpu_sum_evals(
-              uint pop_size,
+              int pop_size,
      __global int* restrict dockpars_evals_of_new_entities,
      __global int* restrict evals_of_runs
              )
@@ -38,7 +38,7 @@ gpu_sum_evals(
 	int entity_counter;
 	__local int partsum_evals[NUM_OF_THREADS_PER_BLOCK];
 
-	uint tidx = get_local_id(0);
+	int tidx = get_local_id(0);
 	partsum_evals[tidx] = 0;
 
 	// calculate partial sums
@@ -49,7 +49,7 @@ gpu_sum_evals(
 		partsum_evals[tidx] += dockpars_evals_of_new_entities[get_group_id(0)*pop_size + entity_counter];
 	}
 	// reduction to calculate energy
-	for (uint off=NUM_OF_THREADS_PER_BLOCK>>1; off>0; off >>= 1)
+	for (int off=NUM_OF_THREADS_PER_BLOCK>>1; off>0; off >>= 1)
 	{
 		barrier(CLK_LOCAL_MEM_FENCE);
 		if (tidx < off)

--- a/device/kernel3.cl
+++ b/device/kernel3.cl
@@ -84,9 +84,9 @@ __constant       kernelconstant_conform*      kerconst_conform
 	__local float genotype_deviate  [ACTUAL_GENOTYPE_LENGTH];
 	__local float genotype_bias     [ACTUAL_GENOTYPE_LENGTH];
         __local float rho;
-	__local int   cons_succ;
-	__local int   cons_fail;
-	__local int   iteration_cnt;
+	__local uint  cons_succ;
+	__local uint  cons_fail;
+	__local uint  iteration_cnt;
 	__local float candidate_energy;
 	__local int   evaluation_cnt;
 	int gene_counter;
@@ -104,7 +104,7 @@ __constant       kernelconstant_conform*      kerconst_conform
 	__local float partial_intraE [NUM_OF_THREADS_PER_BLOCK];
 	#endif
 
-	uint tidx = get_local_id(0);
+	int tidx = get_local_id(0);
 	// Determining run ID and entity ID
 	// Initializing offspring genotype
 	if (tidx == 0)

--- a/device/kernel4.cl
+++ b/device/kernel4.cl
@@ -98,7 +98,7 @@ gpu_gen_and_eval_newpops(
 	__local float partial_intraE [NUM_OF_THREADS_PER_BLOCK];
 	#endif
 
-	uint tidx = get_local_id(0);
+	int tidx = get_local_id(0);
 	// In this case this compute-unit is responsible for elitist selection
 	if ((get_group_id(0) % dockpars_pop_size) == 0) {
 		gpu_perform_elitist_selection(dockpars_pop_size,

--- a/device/kernel_ad.cl
+++ b/device/kernel_ad.cl
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 // Adadelta parameters (TODO: to be moved to header file?)
 //#define RHO             0.9f
-//#define EPSILON         1e-6
+//#define EPSILON         1e-6f
 #define RHO             0.8f
 #define EPSILON         1e-2f
 
@@ -113,7 +113,7 @@ gradient_minAD(
 	// -----------------------------------------------------------------------------
 	// -----------------------------------------------------------------------------
 	// -----------------------------------------------------------------------------
-	uint tidx = get_local_id(0);
+	int tidx = get_local_id(0);
 
 	// Determining entity, and its run, energy, and genotype
 	__local int   entity_id;
@@ -302,7 +302,7 @@ gradient_minAD(
 #endif // DEBUG_ADADELTA_INITIAL_2BRT
 
 	// Initializing vectors
-	for(uint i = tidx;
+	for( int i = tidx;
 	         i < dockpars_num_of_genes;
 	         i+= NUM_OF_THREADS_PER_BLOCK)
 	{
@@ -414,7 +414,7 @@ gradient_minAD(
 			#endif
 
 			#if defined (PRINT_ADADELTA_GENES_AND_GRADS)
-			for(uint i = 0; i < dockpars_num_of_genes; i++) {
+			for(int i = 0; i < dockpars_num_of_genes; i++) {
 				if (i == 0) {
 					printf("\n%s\n", "----------------------------------------------------------");
 					printf("%13s %13s %5s %15s %15s\n", "gene_id", "gene.value", "|", "gene.grad", "(autodockdevpy units)");
@@ -424,7 +424,7 @@ gradient_minAD(
 			#endif
 
 			#if defined (PRINT_ADADELTA_ATOMIC_COORDS)
-			for(uint i = 0; i < dockpars_num_of_atoms; i++) {
+			for(int i = 0; i < dockpars_num_of_atoms; i++) {
 				if (i == 0) {
 					printf("\n%s\n", "----------------------------------------------------------");
 					printf("%s\n", "Coordinates calculated by calcenergy.cl");
@@ -438,7 +438,7 @@ gradient_minAD(
 		barrier(CLK_LOCAL_MEM_FENCE);
 		#endif // DEBUG_ENERGY_ADADELTA
 
-		for(uint i = tidx;
+		for( int i = tidx;
 		         i < dockpars_num_of_genes;
 		         i+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -463,7 +463,7 @@ gradient_minAD(
 
 		#if defined (DEBUG_SQDELTA_ADADELTA)
 		if (/*(get_group_id(0) == 0) &&*/ (tidx == 0)) {
-			for(uint i = 0; i < dockpars_num_of_genes; i++) {
+			for(int i = 0; i < dockpars_num_of_genes; i++) {
 				if (i == 0) {
 					printf("\n%s\n", "----------------------------------------------------------");
 					printf("%13s %20s %15s %15s %15s\n", "gene", "sq_grad", "delta", "sq_delta", "new.genotype");
@@ -526,7 +526,7 @@ gradient_minAD(
 	// -----------------------------------------------------------------------------
 
 	// Mapping torsion angles
-	for (uint gene_counter = tidx+3;
+	for ( int gene_counter = tidx+3;
 	          gene_counter < dockpars_num_of_genes;
 	          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 	{

--- a/device/kernel_fire.cl
+++ b/device/kernel_fire.cl
@@ -378,7 +378,7 @@ gradient_minFire(
 	__local float power;
 
 	// Calculating gradient-norm components
-	for (uint gene_counter = tidx;
+	for ( int gene_counter = tidx;
 	          gene_counter < dockpars_num_of_genes;
 	          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 	{
@@ -397,7 +397,7 @@ gradient_minFire(
 		inv_gradient_norm = 0.0f;
 		
 		// Summing up squares to continue calculation of "gradient-norm"
-		for (uint i = 0; i < dockpars_num_of_genes; i++) {
+		for (int i = 0; i < dockpars_num_of_genes; i++) {
 			inv_gradient_norm += gradient_tmp [i];
 		}
 		
@@ -409,7 +409,7 @@ gradient_minFire(
 
 	// Starting velocity
 	// This equation was found by trial and error
-	for (uint gene_counter = tidx;
+	for ( int gene_counter = tidx;
 	          gene_counter < dockpars_num_of_genes;
 	          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 	{
@@ -421,7 +421,7 @@ gradient_minFire(
 	// may or may not be the last genotype
 	if (tidx == 0) {
 		best_energy = energy;
-		for (uint i = 0; i < dockpars_num_of_genes; i++) {
+		for (int i = 0; i < dockpars_num_of_genes; i++) {
 			best_genotype [i] = genotype [i];
 		}
 	}
@@ -447,7 +447,7 @@ gradient_minFire(
 		#endif
 
 		// Creating new (candidate) genotypes
-		for (uint gene_counter = tidx;
+		for ( int gene_counter = tidx;
 		          gene_counter < dockpars_num_of_genes;
 		          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -625,7 +625,7 @@ gradient_minFire(
 		// force = -gradient
 		barrier(CLK_LOCAL_MEM_FENCE);
 
-		for (uint gene_counter = tidx;
+		for ( int gene_counter = tidx;
 		          gene_counter < dockpars_num_of_genes;
 		          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -637,7 +637,7 @@ gradient_minFire(
 		if (tidx == 0) {
 			power = 0.0f;
 			// Summing dot products
-			for (uint i = 0; i < dockpars_num_of_genes; i++) {
+			for (int i = 0; i < dockpars_num_of_genes; i++) {
 				power += power_tmp [i];
 			}
 		}
@@ -662,7 +662,7 @@ gradient_minFire(
 			printf("%-15s %-10u \n\n",   "count_success: " ,  count_success);
 
 			#if defined (PRINT_FIRE_GENES_AND_GRADS)
-			for(uint i = 0; i < dockpars_num_of_genes; i++) {
+			for(int i = 0; i < dockpars_num_of_genes; i++) {
 				if (i == 0) {
 					//printf("\n%s\n", "----------------------------------------------------------");
 					printf("%13s %13s %5s %15s %21s %15s\n", "gene_id", "genotype", "|", "gradient", "(autodockdevpy units)", "velocity");
@@ -670,7 +670,7 @@ gradient_minFire(
 				printf("%13u %13.6f %5s %15.6f %21.6f %15.6f\n", i, genotype[i], "|", gradient[i], (i<3)? (gradient[i]/dockpars_grid_spacing):(gradient[i]*180.0f/PI_FLOAT), velocity[i]);
 			}
 
-			for(uint i = 0; i < dockpars_num_of_genes; i++) {
+			for(int i = 0; i < dockpars_num_of_genes; i++) {
 				if (i == 0) {
 					//printf("\n%s\n", "----------------------------------------------------------");
 					printf("\n");
@@ -681,7 +681,7 @@ gradient_minFire(
 			#endif
 
 			#if defined (PRINT_FIRE_ATOMIC_COORDS)
-			for(uint i = 0; i < dockpars_num_of_atoms; i++) {
+			for(int i = 0; i < dockpars_num_of_atoms; i++) {
 				if (i == 0) {
 					printf("\n%s\n", "----------------------------------------------------------");
 					printf("%s\n", "Coordinates calculated by calcenergy.cl");
@@ -698,7 +698,7 @@ gradient_minFire(
 		// Going uphill (against the gradient)
 		if (power < 0.0f) {
 			// Using same equation as for starting velocity
-			for (uint gene_counter = tidx;
+			for ( int gene_counter = tidx;
 			          gene_counter < dockpars_num_of_genes;
 			          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 			{
@@ -711,7 +711,7 @@ gradient_minFire(
 				inv_gradient_norm = 0.0f;
 
 				// Summing dot products
-				for (uint i = 0; i < dockpars_num_of_genes; i++) {
+				for (int i = 0; i < dockpars_num_of_genes; i++) {
 					inv_gradient_norm += gradient_tmp [i];
 				}
 
@@ -721,7 +721,7 @@ gradient_minFire(
 			}
 			barrier(CLK_LOCAL_MEM_FENCE);
 
-			for (uint gene_counter = tidx;
+			for ( int gene_counter = tidx;
 			          gene_counter < dockpars_num_of_genes;
 			          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 			{
@@ -771,7 +771,7 @@ gradient_minFire(
 
 		// --------------------------------------
 		// Always update: energy, genotype, gradient
-		for (uint gene_counter = tidx;
+		for ( int gene_counter = tidx;
 		          gene_counter < dockpars_num_of_genes;
 		          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -785,7 +785,7 @@ gradient_minFire(
 
 		// --------------------------------------
 		// Calculating gradient-norm
-		for (uint gene_counter = tidx;
+		for ( int gene_counter = tidx;
 		          gene_counter < dockpars_num_of_genes;
 		          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -797,7 +797,7 @@ gradient_minFire(
 			inv_gradient_norm = 0.0f;
 
 			// Summing dot products
-			for (uint i = 0; i < dockpars_num_of_genes; i++) {
+			for (int i = 0; i < dockpars_num_of_genes; i++) {
 				inv_gradient_norm += gradient_tmp [i];
 			}
 
@@ -808,7 +808,7 @@ gradient_minFire(
 
 		// --------------------------------------
 		// Calculating velocity-norm
-		for (uint gene_counter = tidx;
+		for ( int gene_counter = tidx;
 		          gene_counter < dockpars_num_of_genes;
 		          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -820,7 +820,7 @@ gradient_minFire(
 			velocity_norm  = 0.0f;
 
 			// Summing dot products
-			for (uint i = 0; i < dockpars_num_of_genes; i++) {
+			for (int i = 0; i < dockpars_num_of_genes; i++) {
 				velocity_norm += velocity_tmp [i];
 			}
 
@@ -832,7 +832,7 @@ gradient_minFire(
 
 		// --------------------------------------
 		// Calculating velocity
-		for (uint gene_counter = tidx;
+		for ( int gene_counter = tidx;
 		          gene_counter < dockpars_num_of_genes;
 		          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -857,7 +857,7 @@ gradient_minFire(
 			if (energy <  best_energy) {
 				best_energy = energy;
 
-				for(uint i = 0; i < dockpars_num_of_genes; i++) { 
+				for(int i = 0; i < dockpars_num_of_genes; i++) { 
 					best_genotype[i] = genotype[i];
 				}
 			}
@@ -882,7 +882,7 @@ gradient_minFire(
 	}
 
 	// Mapping torsion angles
-	for (uint gene_counter = tidx;
+	for ( int gene_counter = tidx;
 	          gene_counter < dockpars_num_of_genes;
 	          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 	{

--- a/device/kernel_sd.cl
+++ b/device/kernel_sd.cl
@@ -109,7 +109,7 @@ gradient_minSD(
 	// Stepsize for the minimizer
 	__local float stepsize;
 
-	uint tidx = get_local_id(0);
+	int tidx = get_local_id(0);
 	if (tidx == 0)
 	{
 		// Choosing a random entity out of the entire population
@@ -476,7 +476,7 @@ gradient_minSD(
 		if (/*(get_group_id(0) == 0) &&*/ (tidx == 0)) {
 		
 			#if defined (PRINT_GENES_AND_GRADS)
-			for(uint i = 0; i < dockpars_num_of_genes; i++) {
+			for(int i = 0; i < dockpars_num_of_genes; i++) {
 				if (i == 0) {
 					printf("\n%s\n", "----------------------------------------------------------");
 					printf("%13s %13s %5s %15s %15s\n", "gene_id", "gene.value", "|", "gene.grad", "(autodockdevpy units)");
@@ -486,7 +486,7 @@ gradient_minSD(
 			#endif
 
 			#if defined (PRINT_ATOMIC_COORDS)
-			for(uint i = 0; i < dockpars_num_of_atoms; i++) {
+			for(int i = 0; i < dockpars_num_of_atoms; i++) {
 				if (i == 0) {
 					printf("\n%s\n", "----------------------------------------------------------");
 					printf("%s\n", "Coordinates calculated by calcgradient.cl");
@@ -517,7 +517,7 @@ gradient_minSD(
 		}
 
 		// Copying torsions genes
-		for(uint i = tidx;
+		for( int i = tidx;
 		         i < dockpars_num_of_genes-6;
 		         i+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -527,7 +527,7 @@ gradient_minSD(
 
 		// Calculating maximum absolute torsional gene
 		// https://stackoverflow.com/questions/36465581/opencl-find-max-in-array
-		for (uint i=(dockpars_num_of_genes-6)/2; i>=1; i/=2){
+		for (int i=(dockpars_num_of_genes-6)/2; i>=1; i/=2){
 			if (tidx < i) {
 			// This could be enabled back for details
 			#if 0
@@ -558,7 +558,7 @@ gradient_minSD(
 		}
 		barrier(CLK_LOCAL_MEM_FENCE);
 		
-		for(uint i = tidx; i < dockpars_num_of_genes; i+= NUM_OF_THREADS_PER_BLOCK) {
+		for(int i = tidx; i < dockpars_num_of_genes; i+= NUM_OF_THREADS_PER_BLOCK) {
 			// Taking step
 			candidate_genotype[i] = genotype[i] - stepsize * gradient[i];
 
@@ -572,7 +572,7 @@ gradient_minSD(
 			if (i == 0) {
 				// This could be enabled back for double checking
 				#if 0
-				for(uint i = 0; i < dockpars_num_of_genes; i++) {
+				for(int i = 0; i < dockpars_num_of_genes; i++) {
 					if (i == 0) {
 						printf("\n%s\n", "----------------------------------------------------------");
 						printf("\n%s\n", "After calculating gradients:");
@@ -657,7 +657,7 @@ gradient_minSD(
 			#endif
 
 			#if defined (PRINT_GENES_AND_GRADS)
-			for(uint i = 0; i < dockpars_num_of_genes; i++) {
+			for(int i = 0; i < dockpars_num_of_genes; i++) {
 				if (i == 0) {
 					printf("\n%s\n", "----------------------------------------------------------");
 					printf("%13s %13s %5s %15s %15s\n", "gene_id", "cand-gene.value"/* "gene.value"*/, "|", "gene.grad", "(autodockdevpy units)");
@@ -667,7 +667,7 @@ gradient_minSD(
 			#endif
 
 			#if defined (PRINT_ATOMIC_COORDS)
-			for(uint i = 0; i < dockpars_num_of_atoms; i++) {
+			for(int i = 0; i < dockpars_num_of_atoms; i++) {
 				if (i == 0) {
 					printf("\n%s\n", "----------------------------------------------------------");
 					printf("%s\n", "Coordinates calculated by calcenergy.cl");
@@ -694,7 +694,7 @@ gradient_minSD(
 
 		// Checking if E(candidate_genotype) < E(genotype)
 		if (candidate_energy < energy){
-			for(uint i = tidx;
+			for( int i = tidx;
 			         i < dockpars_num_of_genes;
 			         i+= NUM_OF_THREADS_PER_BLOCK)
 			{
@@ -751,7 +751,7 @@ gradient_minSD(
 		}
 		barrier(CLK_LOCAL_MEM_FENCE);
 
-  	} while ((iteration_cnt < dockpars_max_num_of_iters) && (stepsize > 1E-8));
+	} while ((iteration_cnt < dockpars_max_num_of_iters) && (stepsize > 1E-8f));
 	// -----------------------------------------------------------------------------
 	// -----------------------------------------------------------------------------
 	// -----------------------------------------------------------------------------
@@ -769,7 +769,7 @@ gradient_minSD(
 	}
 
 	// Mapping torsion angles
-	for (uint gene_counter = tidx;
+	for ( int gene_counter = tidx;
 	          gene_counter < dockpars_num_of_genes;
 	          gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 	{


### PR DESCRIPTION
This PR reduces the OpenCL compile warnings to just "no previous prototype function" and should both be performance and result-neutral. I tested this to be true on Diogo's 42 test set. Please do the same :-)

Also, it includes one more double literal fix - let's hope this is really it.