### PR TITLE
Removed initpop.txt output and got rid of silly second random orientation per run.

### DIFF
--- a/Makefile.Cuda
+++ b/Makefile.Cuda
@@ -232,4 +232,4 @@ astex: odock
 #	$(BIN_DIR)/$(TARGET) -ffile ./input_tsri/search-set-astex/$(ASTEX_PDB)/protein.maps.fld -lfile ./input_tsri/search-set-astex/$(ASTEX_PDB)/flex-xray.pdbqt -nrun $(ASTEX_NRUN) -psize $(ASTEX_POPSIZE) -resnam $(ASTEX_TESTNAME) -gfpop 1 | tee ./input_tsri/search-set-astex/intrapairs/$(ASTEX_PDB)_intrapair.txt
 
 clean:
-	rm -f $(BIN_DIR)/* initpop.txt $(HOST_INC_DIR)/performdocking.h $(HOST_SRC_DIR)/performdocking.cpp
+	rm -f $(HOST_INC_DIR)/performdocking.h $(HOST_SRC_DIR)/performdocking.cpp

--- a/Makefile.OpenCL
+++ b/Makefile.OpenCL
@@ -292,4 +292,4 @@ astex: odock
 #	$(BIN_DIR)/$(TARGET) -ffile ./input_tsri/search-set-astex/$(ASTEX_PDB)/protein.maps.fld -lfile ./input_tsri/search-set-astex/$(ASTEX_PDB)/flex-xray.pdbqt -nrun $(ASTEX_NRUN) -psize $(ASTEX_POPSIZE) -resnam $(ASTEX_TESTNAME) -gfpop 1 | tee ./input_tsri/search-set-astex/intrapairs/$(ASTEX_PDB)_intrapair.txt
 
 clean:
-	rm -f $(BIN_DIR)/* initpop.txt $(HOST_INC_DIR)/performdocking.h $(HOST_SRC_DIR)/performdocking.cpp
+	rm -f $(HOST_INC_DIR)/performdocking.h $(HOST_SRC_DIR)/performdocking.cpp

--- a/cuda/calcMergeEneGra.cu
+++ b/cuda/calcMergeEneGra.cu
@@ -176,25 +176,8 @@ __device__ void gpu_calc_energrad(
 				atom_to_rotate.z -= rotation_movingvec.z;
 			}
 
-			float4 quatrot_left = rotation_unitvec;
-			// Performing rotation
-			if (((rotation_list_element & RLIST_GENROT_MASK) != 0) && // If general rotation,
-			    (atom_id < cData.dockpars.true_ligand_atoms))         // two rotations should be performed
-                                                                                  // (multiplying the quaternions)
-			{
-				// Calculating quatrot_left*ref_orientation_quats_const,
-				// which means that reference orientation rotation is the first
-				uint32_t rid4 = 4 * run_id;
-				float4 qt;
-				qt.x = cData.pKerconst_conform->ref_orientation_quats_const[rid4+0];
-				qt.y = cData.pKerconst_conform->ref_orientation_quats_const[rid4+1];
-				qt.z = cData.pKerconst_conform->ref_orientation_quats_const[rid4+2];
-				qt.w = cData.pKerconst_conform->ref_orientation_quats_const[rid4+3];
-				quatrot_left = quaternion_multiply(quatrot_left, qt);
-			}
-
-			// Performing final movement and storing values
-			float4 qt = quaternion_rotate(atom_to_rotate,quatrot_left);
+			// Performing rotation and final movement
+			float4 qt = quaternion_rotate(atom_to_rotate,rotation_unitvec);
 			calc_coords[atom_id].x = qt.x + rotation_movingvec.x;
 			calc_coords[atom_id].y = qt.y + rotation_movingvec.y;
 			calc_coords[atom_id].z = qt.z + rotation_movingvec.z;

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -219,24 +219,8 @@ __device__ void gpu_calc_energy(
 				atom_to_rotate.z -= rotation_movingvec.z;
 			}
 
-			float4 quatrot_left = rotation_unitvec;
-			// Performing rotation
-			if (((rotation_list_element & RLIST_GENROT_MASK) != 0) && // If general rotation,
-			    (atom_id < cData.dockpars.true_ligand_atoms))         // two rotations should be performed
-			                                                          // (multiplying the quaternions)
-			{
-				// Calculating quatrot_left*ref_orientation_quats_const,
-				// which means that reference orientation rotation is the first
-				uint rid4 = 4 * run_id;
-				float4 qt;
-				qt.x = cData.pKerconst_conform->ref_orientation_quats_const[rid4+0];
-				qt.y = cData.pKerconst_conform->ref_orientation_quats_const[rid4+1];
-				qt.z = cData.pKerconst_conform->ref_orientation_quats_const[rid4+2];
-				qt.w = cData.pKerconst_conform->ref_orientation_quats_const[rid4+3];
-				quatrot_left = quaternion_multiply(quatrot_left, qt);
-			}
-			// Performing final movement and storing values
-			float4 qt = quaternion_rotate(atom_to_rotate,quatrot_left);
+			// Performing rotation and final movement
+			float4 qt = quaternion_rotate(atom_to_rotate, rotation_unitvec);
 			calc_coords[atom_id].x = qt.x + rotation_movingvec.x;
 			calc_coords[atom_id].y = qt.y + rotation_movingvec.y;
 			calc_coords[atom_id].z = qt.z + rotation_movingvec.z;

--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -363,7 +363,6 @@ __device__ void gpu_calc_energy(
 		// Calculating atomic_distance
 		float dist = sqrt(subx*subx + suby*suby + subz*subz);
 		float atomic_distance = dist * cData.dockpars.grid_spacing;
-		if(atomic_distance<0.01f) atomic_distance=0.01f;
 
 		// Getting type IDs
 		uint32_t atom1_typeid = cData.pKerconst_interintra->atom_types_const[atom1_id];

--- a/device/calcMergedEneGra.cl
+++ b/device/calcMergedEneGra.cl
@@ -206,23 +206,8 @@ void gpu_calc_energrad(
 				// is needed only if rotating around rotatable bond
 				atom_to_rotate -= rotation_movingvec;
 			}
-			float4 quatrot_left = rotation_unitvec;
-			// Performing rotation
-			if (((rotation_list_element & RLIST_GENROT_MASK) != 0) && // If general rotation,
-			    (atom_id < dockpars_true_ligand_atoms))               // two rotations should be performed
-			                                                          // (multiplying the quaternions)
-			{
-				// Calculating quatrot_left*ref_orientation_quats_const,
-				// which means that reference orientation rotation is the first
-				uint rid4 = (*run_id)<<2;
-				quatrot_left = quaternion_multiply(quatrot_left,
-				                                   (float4)(kerconst_conform->ref_orientation_quats_const[rid4+0],
-				                                            kerconst_conform->ref_orientation_quats_const[rid4+1],
-				                                            kerconst_conform->ref_orientation_quats_const[rid4+2],
-				                                            kerconst_conform->ref_orientation_quats_const[rid4+3]));
-			}
-			// Performing final movement and storing values
-			calc_coords[atom_id] = quaternion_rotate(atom_to_rotate,quatrot_left) + rotation_movingvec;
+			// Performing rotation and final movement
+			calc_coords[atom_id] = quaternion_rotate(atom_to_rotate,rotation_unitvec) + rotation_movingvec;
 		} // End if-statement not dummy rotation
 		barrier(CLK_LOCAL_MEM_FENCE);
 	} // End rotation_counter for-loop

--- a/device/calcenergy.cl
+++ b/device/calcenergy.cl
@@ -428,7 +428,6 @@ if (tidx == 0) {
 
 		// Calculating atomic_distance
 		float atomic_distance = native_sqrt(subx*subx + suby*suby + subz*subz)*dockpars_grid_spacing;
-		if(atomic_distance<0.01f) atomic_distance=0.01f;
 
 		// Getting type IDs
 		uint atom1_typeid = kerconst_interintra->atom_types_const[atom1_id];

--- a/device/calcgradient.cl
+++ b/device/calcgradient.cl
@@ -288,35 +288,6 @@ void gpu_calc_gradient(
 			quatrot_left_y  = sin_angle*rotation_unitvec[1];
 			quatrot_left_z  = sin_angle*rotation_unitvec[2];
 
-			// Performing rotation
-			if (((rotation_list_element & RLIST_GENROT_MASK) != 0) && // If general rotation,
-			    (atom_id < dockpars_true_ligand_atoms))               // two rotations should be performed
-			                                                          // (multiplying the quaternions)
-			{
-				// Calculating quatrot_left*ref_orientation_quats_const,
-				// which means that reference orientation rotation is the first
-				quatrot_temp_q = quatrot_left_q;
-				quatrot_temp_x = quatrot_left_x;
-				quatrot_temp_y = quatrot_left_y;
-				quatrot_temp_z = quatrot_left_z;
-
-				quatrot_left_q = quatrot_temp_q*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+3]-
-				                 quatrot_temp_x*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+0]-
-				                 quatrot_temp_y*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+1]-
-				                 quatrot_temp_z*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+2];
-				quatrot_left_x = quatrot_temp_q*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+0]+
-				                 kerconst_conform->ref_orientation_quats_const[4*(*run_id)+3]*quatrot_temp_x+
-				                 quatrot_temp_y*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+2]-
-				                 kerconst_conform->ref_orientation_quats_const[4*(*run_id)+1]*quatrot_temp_z;
-				quatrot_left_y = quatrot_temp_q*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+1]+
-				                 kerconst_conform->ref_orientation_quats_const[4*(*run_id)+3]*quatrot_temp_y+
-				                 kerconst_conform->ref_orientation_quats_const[4*(*run_id)+0]*quatrot_temp_z-
-				                 quatrot_temp_x*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+2];
-				quatrot_left_z = quatrot_temp_q*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+2]+
-				                 kerconst_conform->ref_orientation_quats_const[4*(*run_id)+3]*quatrot_temp_z+
-				                 quatrot_temp_x*kerconst_conform->ref_orientation_quats_const[4*(*run_id)+1]-
-				                 kerconst_conform->ref_orientation_quats_const[4*(*run_id)+0]*quatrot_temp_y;
-			}
 			quatrot_temp_q = 0 -
 			                 quatrot_left_x*atom_to_rotate [0] -
 			                 quatrot_left_y*atom_to_rotate [1] -

--- a/host/inc/calcenergy.h
+++ b/host/inc/calcenergy.h
@@ -118,7 +118,6 @@ typedef struct
 	float ref_coords_const              [3*MAX_NUM_OF_ATOMS];
 	float rotbonds_moving_vectors_const [3*MAX_NUM_OF_ROTBONDS];
 	float rotbonds_unit_vectors_const   [3*MAX_NUM_OF_ROTBONDS];
-	float ref_orientation_quats_const   [4*MAX_NUM_OF_RUNS];
 } kernelconstant_conform;
 
 typedef struct
@@ -139,7 +138,6 @@ typedef struct
 int prepare_const_fields_for_gpu(
                                  Liganddata*                  myligand_reference,
                                  Dockpars*                    mypars,
-                                 float*                       cpu_ref_ori_angles,
                                  kernelconstant_interintra*   KerConst_interintra,
                                  kernelconstant_intracontrib* KerConst_intracontrib,
                                  kernelconstant_intra*        KerConst_intra,

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -184,7 +184,8 @@ int get_commandpars(
 
 std::vector<float> read_xml_genomes(
                                     char* xml_filename,
-                                    float grid_spacing
+                                    float grid_spacing,
+                                    unsigned int &nrot
                                    );
 
 void gen_initpop_and_reflig(

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -182,6 +182,11 @@ int get_commandpars(
                     const bool late_call = true
                    );
 
+std::vector<float> read_xml_genomes(
+                                    char* xml_filename,
+                                    float grid_spacing
+                                   );
+
 void gen_initpop_and_reflig(
                                   Dockpars*   mypars,
                                   float*      init_populations,

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -95,7 +95,7 @@ typedef struct _Dockpars
 	unsigned long          cons_limit                      = 4;
 	unsigned long          max_num_of_iters                = 300;
 	unsigned long          pop_size                        = 150;
-	bool                   initpop_gen_or_loadfile         = false;
+	char*                  load_xml                        = NULL;
 	int                    gen_pdbs                        = 0;
 	char*                  dpffile                         = NULL;
 	char*                  fldfile                         = NULL;
@@ -104,7 +104,6 @@ typedef struct _Dockpars
 	char*                  xrayligandfile                  = NULL;  // by default will be ligand file name
 	char*                  resname                         = NULL; // by default will be ligand file basename
 	bool                   given_xrayligandfile            = false; // That is, not given (explicitly by the user)
-	float                  ref_ori_angles [3];             // is generated in gen_initpop_and_reflig(...)
 	bool                   autostop                        = true;
 	unsigned int           as_frequency                    = 5;
 	float                  stopstd                         = 0.15;
@@ -186,7 +185,6 @@ int get_commandpars(
 void gen_initpop_and_reflig(
                                   Dockpars*   mypars,
                                   float*      init_populations,
-                                  float*      ref_ori_angles,
                                   Liganddata* myligand,
                             const Gridinfo*   mygrid
                            );

--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -307,7 +307,7 @@ float calc_intraE_f(
                           float        dcutoff,
                           float        smooth,
                           bool         ignore_desolv,
-                    const float        elec_min_distance, 
+                    const float        elec_min_distance,
                           IntraTables& tables,
                           int          debug,
                           float&       interflexE,

--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -238,7 +238,6 @@ void change_conform_f(
                             Liganddata* myligand,
                       const Gridinfo*   mygrid,
                       const float       genotype_f [],
-                            float*      cpu_ref_ori_angles,
                             int         debug
                      );
 

--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -241,6 +241,14 @@ void change_conform_f(
                             int         debug
                      );
 
+void change_conform(
+                          Liganddata* myligand,
+                    const Gridinfo*   mygrid,
+                    const double      genotype [],
+                    const double      axisangle[4],
+                          int         debug
+                   );
+
 float calc_interE_f(
                     const Gridinfo*   mygrid,
                     const Liganddata* myligand,

--- a/host/inc/processresult.h
+++ b/host/inc/processresult.h
@@ -91,7 +91,6 @@ void make_resfiles(
                          int           generations_used,
                    const Gridinfo*     mygrid,
                    const float*        grids,
-                         float*        cpu_ref_ori_angles,
                    const int*          argc,
                          char**        argv,
                          int           debug,

--- a/host/inc/simulation_state.hpp
+++ b/host/inc/simulation_state.hpp
@@ -45,7 +45,6 @@ struct SimulationState{
 	Liganddata         myligand_reference;
 	std::vector<int>   cpu_evals_of_runs;
 	int                generation_cnt;
-	std::vector<float> cpu_ref_ori_angles;
 	float              sec_per_run;
 	unsigned long      total_evals;
 	double             exec_time;

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -1050,17 +1050,11 @@ int get_commandpars(
 				printf("Warning: value of -psize argument ignored. Value must be an integer between 2 and %d.\n", MAX_POPSIZE);
 		}
 
-		// Argument: load initial population from file instead of generating one.
-		// If the value is zero, the initial population will be generated randomly, otherwise it will be loaded from a file.
-		if (strcmp("-pload", argv [i]) == 0)
+		// Argument: load initial population from xml file instead of generating one.
+		if (strcmp("-loadxml", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			sscanf(argv [i+1], "%d", &tempint);
-
-			if (tempint == 0)
-				mypars->initpop_gen_or_loadfile = false;
-			else
-				mypars->initpop_gen_or_loadfile = true;
+			mypars->load_xml = strdup(argv[i+1]);
 		}
 
 		// Argument: number of pdb files to be generated.
@@ -1380,25 +1374,14 @@ int get_commandpars(
 void gen_initpop_and_reflig(
                                   Dockpars*   mypars,
                                   float*      init_populations,
-                                  float*      ref_ori_angles,
                                   Liganddata* myligand,
                             const Gridinfo*   mygrid
                            )
 // The function generates a random initial population
-// (or alternatively, it reads from an external file according to mypars),
-// and the angles of the reference orientation.
-// The parameters mypars, myligand and mygrid describe the current docking.
-// The pointers init_population and ref_ori_angles have to point to
-// two allocated memory regions with proper size which the function will fill with random values.
-// Each contiguous GENOTYPE_LENGTH_IN_GLOBMEM pieces of floats in init_population corresponds to a genotype,
-// and each contiguous three pieces of floats in ref_ori_angles corresponds to
-// the phi, theta and angle genes of the reference orientation.
-// In addition, as part of reference orientation handling,
-// the function moves myligand to origo and scales it according to grid spacing.
+// Each contiguous GENOTYPE_LENGTH_IN_GLOBMEM pieces of floats in init_population corresponds to a genotype
 {
 	int entity_id, gene_id;
-	int gen_pop, gen_seeds;
-	FILE* fp;
+	int gen_seeds;
 	int i;
 	float init_orientation[MAX_NUM_OF_ROTBONDS+6];
 	double movvec_to_origo[3];
@@ -1410,148 +1393,16 @@ void gen_initpop_and_reflig(
 	float x, y, z, s; // convert quaternion to angles
 	float phi, theta, rotangle;
 
-	// initial population
-	gen_pop = 0;
-
-	// Reading initial population from file if only 1 run was requested
-	if (mypars->initpop_gen_or_loadfile)
-	{
-		if (mypars->num_of_runs != 1)
-		{
-			printf("Warning: more than 1 run was requested. New populations will be generated \ninstead of being loaded from initpop.txt\n");
-			gen_pop = 1;
-		}
-		else
-		{
-			fp = fopen("initpop.txt","rb"); // fp = fopen("initpop.txt","r");
-			if (fp == NULL)
-			{
-				printf("Warning: can't find initpop.txt. A new population will be generated.\n");
-				gen_pop = 1;
-			}
-			else
-			{
-				for (entity_id=0; entity_id<pop_size; entity_id++)
-					for (gene_id=0; gene_id<MAX_NUM_OF_ROTBONDS+6; gene_id++)
-						fscanf(fp, "%f", &(init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+gene_id]));
-
-				// reading reference orienation angles from file
-				fscanf(fp, "%f", &(mypars->ref_ori_angles[0]));
-				fscanf(fp, "%f", &(mypars->ref_ori_angles[1]));
-				fscanf(fp, "%f", &(mypars->ref_ori_angles[2]));
-
-				fclose(fp);
-			}
-		}
-	}
-	else
-		gen_pop = 1;
-
 	// Local random numbers for thread safety/reproducibility
 	LocalRNG r(mypars->seed);
 
 	// Generating initial population
-	if (gen_pop == 1)
-	{
-		for (entity_id=0; entity_id<pop_size*mypars->num_of_runs; entity_id++)
-		{
-			for (gene_id=0; gene_id<3; gene_id++)
-			{
-				init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+gene_id] = r.random_float()*(mygrid->size_xyz_angstr[gene_id]);
-			}
-			// generate random quaternion
-			u1 = r.random_float();
-			u2 = r.random_float();
-			u3 = r.random_float();
-			qw = sqrt(1.0 - u1) * sin(PI_TIMES_2 * u2);
-			qx = sqrt(1.0 - u1) * cos(PI_TIMES_2 * u2);
-			qy = sqrt(      u1) * sin(PI_TIMES_2 * u3);
-			qz = sqrt(      u1) * cos(PI_TIMES_2 * u3);
-
-			// convert to angle representation
-			rotangle = 2.0 * acos(qw);
-			s = sqrt(1.0 - (qw * qw));
-			if (s < 0.001){ // rotangle too small
-				x = qx;
-				y = qy;
-				z = qz;
-			} else {
-				x = qx / s;
-				y = qy / s;
-				z = qz / s;
-			}
-
-			theta = acos(z);
-			phi = atan2(y, x);
-
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+3] = phi / DEG_TO_RAD;
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+4] = theta / DEG_TO_RAD;
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+5] = rotangle / DEG_TO_RAD;
-
-			//printf("angles = %8.2f, %8.2f, %8.2f\n", phi / DEG_TO_RAD, theta / DEG_TO_RAD, rotangle/DEG_TO_RAD);
-
-			/*
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+3] = (float) myrand() * 360.0;
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+4] = (float) myrand() * 360.0;
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+5] = (float) myrand() * 360.0;
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+3] = (float) myrand() * 360;
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+4] = (float) myrand() * 180;
-			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+5] = (float) myrand() * 360;
-			*/
-
-			for (gene_id=6; gene_id<MAX_NUM_OF_ROTBONDS+6; gene_id++) {
-				init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+gene_id] = r.random_float()*360;
-			}
-		}
-
-		// Writing first initial population to initpop.txt
-		fp = fopen("initpop.txt", "w");
-		if (fp == NULL)
-			printf("Warning: can't create initpop.txt.\n");
-		else
-		{
-			for (entity_id=0; entity_id<pop_size; entity_id++)
-				for (gene_id=0; gene_id<MAX_NUM_OF_ROTBONDS+6; gene_id++)
-					fprintf(fp, "%f ", init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+gene_id]);
-
-			// writing reference orientation angles to initpop.txt
-			fprintf(fp, "%f ", mypars->ref_ori_angles[0]);
-			fprintf(fp, "%f ", mypars->ref_ori_angles[1]);
-			fprintf(fp, "%f ", mypars->ref_ori_angles[2]);
-
-			fclose(fp);
-		}
-	}
-
-	// genotypes should contain x, y and z genes in grid spacing instead of Angstroms
-	// (but was previously generated in Angstroms since fdock does the same)
-
 	for (entity_id=0; entity_id<pop_size*mypars->num_of_runs; entity_id++)
-		for (gene_id=0; gene_id<3; gene_id++)
-			init_populations [entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+gene_id] = init_populations [entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+gene_id]/mygrid->spacing;
-
-	// changing initial orientation of reference ligand
-	/*for (i=0; i<38; i++)
-		switch (i)
-		{
-		case 3: init_orientation [i] = mypars->ref_ori_angles [0];
-				break;
-		case 4: init_orientation [i] = mypars->ref_ori_angles [1];
-				break;
-		case 5: init_orientation [i] = mypars->ref_ori_angles [2];
-				break;
-		default: init_orientation [i] = 0;
-		}
-
-	change_conform_f(myligand, init_orientation, 0);*/
-
-	// initial orientation will be calculated during docking,
-	// only the required angles are generated here,
-	// but the angles possibly read from file are ignored
-
-	for (i=0; i<mypars->num_of_runs; i++)
 	{
-		// uniform distr.
+		// randomize location and convert to grid coordinates
+		for (gene_id=0; gene_id<3; gene_id++)
+			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+gene_id] = r.random_float()*(mygrid->size_xyz_angstr[gene_id])/mygrid->spacing;
+		
 		// generate random quaternion
 		u1 = r.random_float();
 		u2 = r.random_float();
@@ -1560,7 +1411,7 @@ void gen_initpop_and_reflig(
 		qx = sqrt(1.0 - u1) * cos(PI_TIMES_2 * u2);
 		qy = sqrt(      u1) * sin(PI_TIMES_2 * u3);
 		qz = sqrt(      u1) * cos(PI_TIMES_2 * u3);
-
+		
 		// convert to angle representation
 		rotangle = 2.0 * acos(qw);
 		s = sqrt(1.0 - (qw * qw));
@@ -1573,15 +1424,17 @@ void gen_initpop_and_reflig(
 			y = qy / s;
 			z = qz / s;
 		}
-
 		theta = acos(z);
 		phi = atan2(y, x);
-
-		ref_ori_angles[3*i]   = phi / DEG_TO_RAD;
-		ref_ori_angles[3*i+1] = theta / DEG_TO_RAD;
-		ref_ori_angles[3*i+2] = rotangle / DEG_TO_RAD;
+		
+		init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+3] = phi / DEG_TO_RAD;
+		init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+4] = theta / DEG_TO_RAD;
+		init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+5] = rotangle / DEG_TO_RAD;
+		for (gene_id=6; gene_id<MAX_NUM_OF_ROTBONDS+6; gene_id++) {
+			init_populations[entity_id*GENOTYPE_LENGTH_IN_GLOBMEM+gene_id] = r.random_float()*360;
+		}
 	}
-
+	
 	get_movvec_to_origo(myligand, movvec_to_origo);
 	double flex_vec[3];
 	for (unsigned int i=0; i<3; i++)
@@ -1589,9 +1442,4 @@ void gen_initpop_and_reflig(
 	move_ligand(myligand, movvec_to_origo, flex_vec);
 	scale_ligand(myligand, 1.0/mygrid->spacing);
 	get_moving_and_unit_vectors(myligand);
-
-	/*
-	printf("ligand: movvec_to_origo: %f %f %f\n", movvec_to_origo[0], movvec_to_origo[1], movvec_to_origo[2]);
-	*/
-
 }

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -1464,7 +1464,7 @@ std::vector<float> read_xml_genomes(
 					error=9;
 					break;
 				}
-				theta=atan(sqrt((*gene)*(*gene)+(*(gene+1))*(*(gene+1)))/(*(gene+2)));
+				theta=acos(*(gene+2)/sqrt((*gene)*(*gene)+(*(gene+1))*(*(gene+1))+(*(gene+2))*(*(gene+2))));
 				phi=atan2(*(gene+1),*gene);
 				*gene = phi / DEG_TO_RAD;
 				*(gene+1) = theta / DEG_TO_RAD;

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -365,13 +365,10 @@ parameters argc and argv:
 	cpu_init_populations = sim_state.cpu_populations.data();
 	cpu_final_populations = sim_state.cpu_populations.data();
 
-	// allocating memory in CPU for reference orientation angles
-	sim_state.cpu_ref_ori_angles.resize(mypars->num_of_runs*3);
-
 	// generating initial populations and random orientation angles of reference ligand
 	// (ligand will be moved to origo and scaled as well)
 	myligand_reference = *myligand_init;
-	gen_initpop_and_reflig(mypars, cpu_init_populations, sim_state.cpu_ref_ori_angles.data(), &myligand_reference, mygrid);
+	gen_initpop_and_reflig(mypars, cpu_init_populations, &myligand_reference, mygrid);
 
 	// allocating memory in CPU for pseudorandom number generator seeds and
 	// generating them (seed for each thread during GA)
@@ -390,21 +387,6 @@ parameters argc and argv:
 	memset(sim_state.cpu_evals_of_runs.data(), 0, size_evals_of_runs);
 
 	//preparing the constant data fields for the GPU
-	// ----------------------------------------------------------------------
-	// The original function does CUDA calls initializing const Kernel data.
-	// We create a struct to hold those constants
-	// and return them <here> (<here> = where prepare_const_fields_for_gpu() is called),
-	// so we can send them to Kernels from <here>, instead of from calcenergy.cpp as originally.
-	// ----------------------------------------------------------------------
-	// Constant struct
-
-/*
-	kernelconstant KerConst;
-
-	if (prepare_const_fields_for_gpu(&myligand_reference, mypars, cpu_ref_ori_angles, &KerConst) == 1)
-		return 1;
-*/
-	//GpuData cData; //JL Now pass this in
 	kernelconstant_interintra   KerConst_interintra;
 	kernelconstant_intracontrib KerConst_intracontrib;
 	kernelconstant_intra        KerConst_intra;
@@ -412,7 +394,7 @@ parameters argc and argv:
 	kernelconstant_conform      KerConst_conform;
 	kernelconstant_grads        KerConst_grads;
 
-	if (prepare_const_fields_for_gpu(&myligand_reference, mypars, sim_state.cpu_ref_ori_angles.data(),
+	if (prepare_const_fields_for_gpu(&myligand_reference, mypars,
 	                                 &KerConst_interintra,
 	                                 &KerConst_intracontrib,
 	                                 &KerConst_intra,

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -680,9 +680,9 @@ parameters argc and argv:
 
         // Get profile for timing
 	profile.adadelta=(strcmp(mypars->ls_method, "ad")==0);
-        profile.n_evals = mypars->num_of_energy_evals;
-        profile.num_atoms = myligand_reference.num_of_atoms;
-        profile.num_rotbonds = myligand_init->num_of_rotbonds;
+	profile.n_evals = mypars->num_of_energy_evals;
+	profile.num_atoms = myligand_reference.num_of_atoms;
+	profile.num_rotbonds = myligand_init->num_of_rotbonds;
 
 	/*
 	printf("dockpars.num_of_intraE_contributors:%u\n", dockpars.num_of_intraE_contributors);

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -447,13 +447,10 @@ parameters argc and argv:
 	cpu_init_populations = sim_state.cpu_populations.data();
 	cpu_final_populations = sim_state.cpu_populations.data();
 
-	// allocating memory in CPU for reference orientation angles
-	sim_state.cpu_ref_ori_angles.resize(mypars->num_of_runs*3);
-
 	// generating initial populations and random orientation angles of reference ligand
 	// (ligand will be moved to origo and scaled as well)
 	myligand_reference = *myligand_init;
-	gen_initpop_and_reflig(mypars, cpu_init_populations, sim_state.cpu_ref_ori_angles.data(), &myligand_reference, mygrid);
+	gen_initpop_and_reflig(mypars, cpu_init_populations, &myligand_reference, mygrid);
 
 	// allocating memory in CPU for pseudorandom number generator seeds and
 	// generating them (seed for each thread during GA)
@@ -471,21 +468,6 @@ parameters argc and argv:
 	memset(sim_state.cpu_evals_of_runs.data(), 0, size_evals_of_runs);
 
 	// preparing the constant data fields for the GPU
-	// ----------------------------------------------------------------------
-	// The original function does CUDA calls initializing const Kernel data.
-	// We create a struct to hold those constants
-	// and return them <here> (<here> = where prepare_const_fields_for_gpu() is called),
-	// so we can send them to Kernels from <here>, instead of from calcenergy.cpp as originally.
-	// ----------------------------------------------------------------------
-	// Constant struct
-
-/*
-	kernelconstant KerConst;
-
-	if (prepare_const_fields_for_gpu(&myligand_reference, mypars, cpu_ref_ori_angles, &KerConst) == 1)
-		return 1;
-*/
-
 	kernelconstant_interintra	KerConst_interintra;
 	kernelconstant_intracontrib	KerConst_intracontrib;
 	kernelconstant_intra		KerConst_intra;
@@ -493,7 +475,7 @@ parameters argc and argv:
 	kernelconstant_conform		KerConst_conform;
 	kernelconstant_grads		KerConst_grads;
 
-	if (prepare_const_fields_for_gpu(&myligand_reference, mypars, sim_state.cpu_ref_ori_angles.data(),
+	if (prepare_const_fields_for_gpu(&myligand_reference, mypars,
 	                                 &KerConst_interintra,
 	                                 &KerConst_intracontrib,
 	                                 &KerConst_intra,

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -1590,24 +1590,44 @@ void change_conform_f(
                             int         debug
                      )
 // The function changes the conformation of myligand according to
-// the genotype given by the second parameter.
+// the floating point genotype from GPU
+{
+	double genotype [ACTUAL_GENOTYPE_LENGTH];
+	for (unsigned int i=0; i<ACTUAL_GENOTYPE_LENGTH; i++)
+		genotype [i] = genotype_f [i];
+	change_conform(myligand,mygrid,genotype,NULL,debug);
+}
+
+void change_conform(
+                          Liganddata* myligand,
+                    const Gridinfo*   mygrid,
+                    const double      genotype [],
+                    const double      axisangle[4],
+                          int         debug
+                   )
+// The function changes the conformation of myligand according to
+// the genotype and (optionally) the general rotation in axisangle
 {
 	double genrot_movvec [3] = {0, 0, 0};
 	double genrot_unitvec [3];
+	double genrot_angle;
 	double movvec_to_origo [3];
-	double phi, theta;
-	int atom_id, rotbond_id, i;
-	double genotype [ACTUAL_GENOTYPE_LENGTH];
+	int atom_id, rotbond_id;
 
-	for (i=0; i<ACTUAL_GENOTYPE_LENGTH; i++)
-		genotype [i] = genotype_f [i];
-
-	phi = (genotype [3])/180*PI;
-	theta = (genotype [4])/180*PI;
-
-	genrot_unitvec [0] = sin(theta)*cos(phi);
-	genrot_unitvec [1] = sin(theta)*sin(phi);
-	genrot_unitvec [2] = cos(theta);
+	if(!axisangle){
+		double phi = (genotype [3])/180*PI;
+		double theta = (genotype [4])/180*PI;
+		
+		genrot_unitvec [0] = sin(theta)*cos(phi);
+		genrot_unitvec [1] = sin(theta)*sin(phi);
+		genrot_unitvec [2] = cos(theta);
+		genrot_angle = genotype[5];
+	} else{
+		genrot_unitvec [0] = axisangle[0];
+		genrot_unitvec [1] = axisangle[1];
+		genrot_unitvec [2] = axisangle[2];
+		genrot_angle = axisangle[3];
+	}
 
 	get_movvec_to_origo(myligand, movvec_to_origo); // moving ligand to origo
 	move_ligand(myligand, movvec_to_origo);
@@ -1637,7 +1657,7 @@ void change_conform_f(
 			rotate(&(myligand->atom_idxyzq[atom_id][1]),
 			       genrot_movvec,
 			       genrot_unitvec,
-			       &(genotype [5]), debug); // general rotation
+			       &genrot_angle, debug); // general rotation
 		}
 	}
 

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -1587,7 +1587,6 @@ void change_conform_f(
                             Liganddata* myligand,
                       const Gridinfo*   mygrid,
                       const float       genotype_f [],
-                            float*      cpu_ref_ori_angles,
                             int         debug
                      )
 // The function changes the conformation of myligand according to
@@ -1599,8 +1598,6 @@ void change_conform_f(
 	double phi, theta;
 	int atom_id, rotbond_id, i;
 	double genotype [ACTUAL_GENOTYPE_LENGTH];
-	double refori_unitvec [3];
-	double refori_angle;
 
 	for (i=0; i<ACTUAL_GENOTYPE_LENGTH; i++)
 		genotype [i] = genotype_f [i];
@@ -1611,19 +1608,6 @@ void change_conform_f(
 	genrot_unitvec [0] = sin(theta)*cos(phi);
 	genrot_unitvec [1] = sin(theta)*sin(phi);
 	genrot_unitvec [2] = cos(theta);
-
-	phi = (cpu_ref_ori_angles [0])/180*PI;
-	theta = (cpu_ref_ori_angles [1])/180*PI;
-
-	refori_unitvec [0] = sin(theta)*cos(phi);
-	refori_unitvec [1] = sin(theta)*sin(phi);
-	refori_unitvec [2] = cos(theta);
-	refori_angle = cpu_ref_ori_angles[2];
-
-// +++++++++++++++++++++++++++++++++++++++
-//printf("cpu_ref_ori_angles [0]: %f, cpu_ref_ori_angles [1]: %f, %f\n",cpu_ref_ori_angles [0],cpu_ref_ori_angles [1],PI);
-//printf("refori_unitvec [0]:%f, refori_unitvec [1]:%f, refori_unitvec [2]:%f\n",refori_unitvec [0],refori_unitvec [1],refori_unitvec [2]);
-// +++++++++++++++++++++++++++++++++++++++
 
 	get_movvec_to_origo(myligand, movvec_to_origo); // moving ligand to origo
 	move_ligand(myligand, movvec_to_origo);
@@ -1650,14 +1634,6 @@ void change_conform_f(
 
 		if (atom_id<myligand->true_ligand_atoms)
 		{
-			if (debug == 1)
-				printf("according to general rotation\n");
-
-			rotate(&(myligand->atom_idxyzq[atom_id][1]),
-			       genrot_movvec,
-			       refori_unitvec,
-			       &refori_angle, debug); // rotating to reference orientation
-
 			rotate(&(myligand->atom_idxyzq[atom_id][1]),
 			       genrot_movvec,
 			       genrot_unitvec,

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -946,6 +946,9 @@ void clusanal_gendlg(
 				fprintf(fp_xml, "%s%s", (i>1)?" ":"", argv[i]);
 			fprintf(fp_xml, "</arguments>\n");
 		}
+		if(mypars->dpffile)
+			fprintf(fp_xml, "\t<dpf>%s</dpf>\n",mypars->dpffile);
+		fprintf(fp_xml, "\t<ligand>%s</ligand>\n", mypars->ligandfile);
 		fprintf(fp_xml, "\t<seed>");
 		if(!mypars->seed[2]){
 			if(!mypars->seed[1]){
@@ -957,9 +960,6 @@ void clusanal_gendlg(
 		fprintf(fp_xml, "\t<autostop>%s</autostop>\n",mypars->autostop ? "yes" : "no");
 		fprintf(fp_xml, "\t<heuristics>%s</heuristics>\n",mypars->use_heuristics ? "yes" : "no");
 		fprintf(fp_xml, "\t<run_requested>%d</run_requested>\n",mypars->num_of_runs);
-		if(mypars->dpffile)
-			fprintf(fp_xml, "\t<dpf>%s</dpf>\n",mypars->dpffile);
-		fprintf(fp_xml, "\t<ligand>%s</ligand>\n", mypars->ligandfile);
 		fprintf(fp_xml, "\t<runs>\n");
 		double phi, theta;
 		for(j=0; j<num_of_runs; j++){

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -957,17 +957,17 @@ void clusanal_gendlg(
 		fprintf(fp_xml, "\t<autostop>%s</autostop>\n",mypars->autostop ? "yes" : "no");
 		fprintf(fp_xml, "\t<heuristics>%s</heuristics>\n",mypars->use_heuristics ? "yes" : "no");
 		fprintf(fp_xml, "\t<run_requested>%d</run_requested>\n",mypars->num_of_runs);
+		if(mypars->dpffile)
+			fprintf(fp_xml, "\t<dpf>%s</dpf>\n",mypars->dpffile);
+		fprintf(fp_xml, "\t<ligand>%s</ligand>\n", mypars->ligandfile);
 		fprintf(fp_xml, "\t<runs>\n");
 		double phi, theta;
 		for(j=0; j<num_of_runs; j++){
 			fprintf(fp_xml, "\t\t<run id=\"%d\">\n",(myresults [j]).run_number);
-			if(mypars->dpffile)
-				fprintf(fp_xml, "\t\t\t<dpf>%s</dpf>\n",mypars->dpffile);
 			fprintf(fp_xml, "\t\t\t<free_NRG_binding>   %.2f</free_NRG_binding>\n", myresults[j].interE + myresults[j].interflexE + torsional_energy);
 			fprintf(fp_xml, "\t\t\t<final_intermol_NRG> %.2f</final_intermol_NRG>\n", myresults[j].interE + myresults[j].interflexE);
 			fprintf(fp_xml, "\t\t\t<internal_ligand_NRG>%.2f</internal_ligand_NRG>\n", myresults[j].intraE + myresults[j].intraflexE);
 			fprintf(fp_xml, "\t\t\t<torsonial_free_NRG> %.2f</torsonial_free_NRG>\n", torsional_energy);
-			fprintf(fp_xml, "\t\t\t<move>%s</move>\n", mypars->ligandfile);
 			fprintf(fp_xml, "\t\t\t<tran0>%.6f %.6f %.6f</tran0>\n", myresults[j].genotype[0]*mygrid->spacing, myresults[j].genotype[1]*mygrid->spacing, myresults[j].genotype[2]*mygrid->spacing);
 			phi = myresults[j].genotype[3]/180.0*PI;
 			theta = myresults[j].genotype[4]/180.0*PI;

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -948,7 +948,10 @@ void clusanal_gendlg(
 		}
 		if(mypars->dpffile)
 			fprintf(fp_xml, "\t<dpf>%s</dpf>\n",mypars->dpffile);
+		fprintf(fp_xml, "\t<grid>%s</grid>\n", mypars->fldfile);
 		fprintf(fp_xml, "\t<ligand>%s</ligand>\n", mypars->ligandfile);
+		if(mypars->flexresfile)
+			fprintf(fp_xml, "\t<flexres>%s</flexres>\n",mypars->flexresfile);
 		fprintf(fp_xml, "\t<seed>");
 		if(!mypars->seed[2]){
 			if(!mypars->seed[1]){

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -116,10 +116,10 @@ void write_basic_info(
 	fprintf(fp, "Number of pdb files to be generated:       %d\n", mypars->gen_pdbs);
 
 	fprintf(fp, "Initial population:                        ");
-	if (!mypars->initpop_gen_or_loadfile)
+	if (!mypars->load_xml)
 		fprintf(fp, "GENERATE\n");
 	else
-		fprintf(fp, "LOAD FROM FILE (initpop.txt)\n");
+		fprintf(fp, "LOAD FROM FILE (%s)\n",mypars->load_xml);
 
 	fprintf(fp, "\n\nProgram call in command line was:          ");
 	for (i=0; i<*argc; i++)
@@ -297,7 +297,6 @@ void make_resfiles(
                          int           generations_used,
                    const Gridinfo*     mygrid,
                    const float*        grids,
-                         float*        cpu_ref_ori_angles,
                    const int*          argc,
                          char**        argv,
                          int           debug,
@@ -354,7 +353,7 @@ void make_resfiles(
 	{
 		temp_docked = *ligand_ref;
 
-		change_conform_f(&temp_docked, mygrid, final_population+i*GENOTYPE_LENGTH_IN_GLOBMEM, cpu_ref_ori_angles, debug);
+		change_conform_f(&temp_docked, mygrid, final_population+i*GENOTYPE_LENGTH_IN_GLOBMEM, debug);
 		
 		// the map interaction of flex res atoms is stored in accurate_intraflexE[i]
 		accurate_interE[i] = calc_interE_f(mygrid, &temp_docked, grids, 0.0005, debug, accurate_intraflexE[i]);	//calculating the intermolecular energy
@@ -1039,7 +1038,6 @@ void process_result(
 		              sim_state.generation_cnt,
 		              mygrid,
 		              cpu_floatgrids,
-		              sim_state.cpu_ref_ori_angles.data()+3*run_cnt,
 		              argc,
 		              argv,
 		              /*1*/0,

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -946,6 +946,13 @@ void clusanal_gendlg(
 				fprintf(fp_xml, "%s%s", (i>1)?" ":"", argv[i]);
 			fprintf(fp_xml, "</arguments>\n");
 		}
+		fprintf(fp_xml, "\t<seed>");
+		if(!mypars->seed[2]){
+			if(!mypars->seed[1]){
+				fprintf(fp_xml,"%d", mypars->seed[0]);
+			} else fprintf(fp_xml,"%d %d", mypars->seed[0], mypars->seed[1]);
+		} else fprintf(fp_xml,"%d %d %d", mypars->seed[0], mypars->seed[1], mypars->seed[2]);
+		fprintf(fp_xml, "</seed>\n");
 		fprintf(fp_xml, "\t<ls_method>%s</ls_method>\n",mypars->ls_method);
 		fprintf(fp_xml, "\t<autostop>%s</autostop>\n",mypars->autostop ? "yes" : "no");
 		fprintf(fp_xml, "\t<heuristics>%s</heuristics>\n",mypars->use_heuristics ? "yes" : "no");
@@ -954,13 +961,6 @@ void clusanal_gendlg(
 		double phi, theta;
 		for(j=0; j<num_of_runs; j++){
 			fprintf(fp_xml, "\t\t<run id=\"%d\">\n",(myresults [j]).run_number);
-			fprintf(fp_xml, "\t\t\t<seed>");
-			if(!mypars->seed[2]){
-				if(!mypars->seed[1]){
-					fprintf(fp_xml,"%d", mypars->seed[0]);
-				} else fprintf(fp_xml,"%d %d", mypars->seed[0], mypars->seed[1]);
-			} else fprintf(fp_xml,"%d %d %d", mypars->seed[0], mypars->seed[1], mypars->seed[2]);
-			fprintf(fp_xml, "</seed>\n");
 			if(mypars->dpffile)
 				fprintf(fp_xml, "\t\t\t<dpf>%s</dpf>\n",mypars->dpffile);
 			fprintf(fp_xml, "\t\t\t<free_NRG_binding>   %.2f</free_NRG_binding>\n", myresults[j].interE + myresults[j].interflexE + torsional_energy);
@@ -980,31 +980,29 @@ void clusanal_gendlg(
 			fprintf(fp_xml, "\t\t</run>\n");
 		}
 		fprintf(fp_xml, "\t</runs>\n");
-		fprintf(fp_xml, "</autodock_gpu>\n");
-		fprintf(fp_xml, "<result>\n");
-
-		fprintf(fp_xml, "\t<clustering_histogram>\n");
+		fprintf(fp_xml, "\t<result>\n");
+		
+		fprintf(fp_xml, "\t\t<clustering_histogram>\n");
 		for (i=0; i<num_of_clusters; i++)
 		{
-			fprintf(fp_xml, "\t\t<cluster cluster_rank=\"%d\" lowest_binding_energy=\"%.2lf\" run=\"%d\" mean_binding_energy=\"%.2lf\" num_in_clus=\"%d\" />\n",
+			fprintf(fp_xml, "\t\t\t<cluster cluster_rank=\"%d\" lowest_binding_energy=\"%.2lf\" run=\"%d\" mean_binding_energy=\"%.2lf\" num_in_clus=\"%d\" />\n",
 					i+1, best_energy[i], best_energy_runid[i], sum_energy[i]/cluster_sizes[i], cluster_sizes [i]);
 		}
-		fprintf(fp_xml, "\t</clustering_histogram>\n");
-
-		fprintf(fp_xml, "\t<rmsd_table>\n");
+		fprintf(fp_xml, "\t\t</clustering_histogram>\n");
+		
+		fprintf(fp_xml, "\t\t<rmsd_table>\n");
 		for (i=0; i<num_of_clusters; i++)
 		{
 			for (j=0; j<num_of_runs; j++)
 				if (myresults [j].clus_id == i+1)
 				{
-					fprintf(fp_xml, "\t\t<run rank=\"%d\" sub_rank=\"%d\" run=\"%d\" binding_energy=\"%.2lf\" cluster_rmsd=\"%.2lf\" reference_rmsd=\"%.2lf\" />\n",
+					fprintf(fp_xml, "\t\t\t<run rank=\"%d\" sub_rank=\"%d\" run=\"%d\" binding_energy=\"%.2lf\" cluster_rmsd=\"%.2lf\" reference_rmsd=\"%.2lf\" />\n",
 					                     (myresults [j]).clus_id, (myresults [j]).clus_subrank, (myresults [j]).run_number, myresults[j].interE + myresults[j].interflexE + torsional_energy, (myresults [j]).rmsd_from_cluscent, (myresults [j]).rmsd_from_ref);
 				}
 		}
-		fprintf(fp_xml, "\t</rmsd_table>\n");
-
-		fprintf(fp_xml, "</result>\n");
-
+		fprintf(fp_xml, "\t\t</rmsd_table>\n");
+		fprintf(fp_xml, "\t</result>\n");
+		fprintf(fp_xml, "</autodock_gpu>\n");
 		fclose(fp_xml);
 		free(xml_file_name);
 	}


### PR DESCRIPTION
This cleans up the code very nicely, prevents file collisions in case multiple instances are run per folder (initpop.txt), and even should result in a minor speedup.

Please extensively test E50's on both Cuda and OpenCL to make sure everything still behaves correctly :-)