### PR TITLE
Convert XML file output into DLG format

### DIFF
--- a/common/defines.h
+++ b/common/defines.h
@@ -70,7 +70,8 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 
 #define MAX_NUM_OF_ATOMS           256
 #define MAX_NUM_OF_ATYPES          32
-#define MAX_NUM_OF_ROTBONDS        58
+// 57+6 (+1 for eventual angle in axisangle representation) = 63 or 64
+#define MAX_NUM_OF_ROTBONDS        57
 #define MAX_INTRAE_CONTRIBUTORS    (MAX_NUM_OF_ATOMS * MAX_NUM_OF_ATOMS)
 #define MAX_NUM_OF_ROTATIONS       (MAX_NUM_OF_ATOMS * MAX_NUM_OF_ROTBONDS)
 #define MAX_POPSIZE                2048

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -194,7 +194,8 @@ void read_xml_filenames(
 std::vector<float> read_xml_genomes(
                                     char* xml_filename,
                                     float grid_spacing,
-                                    unsigned int &nrot
+                                    unsigned int &nrot,
+                                    bool store_axisangle=false
                                    );
 
 void gen_initpop_and_reflig(

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -112,6 +112,7 @@ typedef struct _Dockpars
 	float                  stopstd                         = 0.15;
 	bool                   cgmaps                          = false; // default is false (use a single map for every CGx or Gx atom type)
 	unsigned long          num_of_runs                     = 20;
+	unsigned int           list_nr                         = 0;
 	bool                   reflig_en_required              = false;
 	int                    unbound_model                   = 0;                 // bound same as unbound, the coefficients
 	AD4_free_energy_coeffs coeffs                          = unbound_models[0]; // are also set in get_filenames_and_ADcoeffs()
@@ -187,9 +188,11 @@ int get_commandpars(
 
 void read_xml_filenames(
                         char* xml_filename,
+                        char* &dpf_filename,
                         char* &grid_filename,
                         char* &ligand_filename,
                         char* &flexres_filename,
+                        unsigned int &list_nr,
                         uint32_t seed[3]
                        );
 

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -97,6 +97,8 @@ typedef struct _Dockpars
 	unsigned long          pop_size                        = 150;
 	char*                  load_xml                        = NULL;
 	bool                   xml2dlg                         = false;
+	unsigned int           xml_files                       = 0;
+	bool                   dlg2stdout                      = false;
 	int                    gen_pdbs                        = 0;
 	char*                  dpffile                         = NULL;
 	char*                  fldfile                         = NULL;

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -96,6 +96,7 @@ typedef struct _Dockpars
 	unsigned long          max_num_of_iters                = 300;
 	unsigned long          pop_size                        = 150;
 	char*                  load_xml                        = NULL;
+	bool                   xml2dlg                         = false;
 	int                    gen_pdbs                        = 0;
 	char*                  dpffile                         = NULL;
 	char*                  fldfile                         = NULL;
@@ -181,6 +182,13 @@ int get_commandpars(
                           Dockpars*,
                     const bool late_call = true
                    );
+
+void read_xml_filenames(
+                        char* xml_filename,
+                        char* &grid_filename,
+                        char* &ligand_filename,
+                        char* &flexres_filename
+                       );
 
 std::vector<float> read_xml_genomes(
                                     char* xml_filename,

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -187,7 +187,8 @@ void read_xml_filenames(
                         char* xml_filename,
                         char* &grid_filename,
                         char* &ligand_filename,
-                        char* &flexres_filename
+                        char* &flexres_filename,
+                        uint32_t seed[3]
                        );
 
 std::vector<float> read_xml_genomes(

--- a/host/inc/processresult.h
+++ b/host/inc/processresult.h
@@ -39,7 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 typedef struct
 {
-	float      genotype[GENOTYPE_LENGTH_IN_GLOBMEM];
+	float*     genotype; // a pointer here is sufficient and saves lots of memory copies
 	Liganddata reslig_realcoord;
 	float      interE;
 	float      interflexE;

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -766,15 +766,15 @@ int get_commandpars(
 		mypars->abs_max_dmov        = 6.0/(*spacing);             // +/-6A
 		mypars->base_dmov_mul_sqrt3 = 2.0/(*spacing)*sqrt(3.0);   // 2 A
 		mypars->xrayligandfile      = strdup(mypars->ligandfile); // By default xray-ligand file is the same as the randomized input ligand
-		if(!mypars->resname){ // only need to set if it's not set yet
-			if(mypars->xml2dlg){
-				if(strlen(mypars->load_xml)>4){ // .xml = 4 chars
-					i=strlen(mypars->load_xml)-4;
-					mypars->resname = (char*)malloc((i+1)*sizeof(char));
-					strncpy(mypars->resname,mypars->load_xml,i);    // Default is ligand file basename
-					mypars->resname[i]='\0';
-				} else mypars->resname = strdup("docking");               // Fallback to old default
-			} else{
+		if(mypars->xml2dlg){
+			if(strlen(mypars->load_xml)>4){ // .xml = 4 chars
+				i=strlen(mypars->load_xml)-4;
+				mypars->resname = (char*)malloc((i+1)*sizeof(char));
+				strncpy(mypars->resname,mypars->load_xml,i);    // Default is ligand file basename
+				mypars->resname[i]='\0';
+			} else if(!mypars->resname) mypars->resname = strdup("docking"); // Fallback to old default
+		} else{
+			if(!mypars->resname){ // only need to set if it's not set yet
 				if(strlen(mypars->ligandfile)>6){ // .pdbqt = 6 chars
 					i=strlen(mypars->ligandfile)-6;
 					mypars->resname = (char*)malloc((i+1)*sizeof(char));

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -155,6 +155,12 @@ int preparse_dpf(
 			}
 			mypars->dpffile = strdup(argv[i+1]);
 		}
+		// Argument: load initial data from xml file and reconstruct dlg, then finish
+		if (strcmp("-xml2dlg", argv [i]) == 0)
+		{
+			mypars->load_xml = strdup(argv[i+1]);
+			mypars->xml2dlg = true;
+		}
 	}
 	if (mypars->dpffile){
 		std::ifstream file(mypars->dpffile);
@@ -534,12 +540,6 @@ int get_filelist(
 				}
 			}
 			filelist.filename = strdup(argv[i+1]);
-		}
-		// Argument: load initial data from xml file and reconstruct dlg, then finish
-		if (strcmp("-xml2dlg", argv [i]) == 0)
-		{
-			mypars->load_xml = strdup(argv[i+1]);
-			mypars->xml2dlg = true;
 		}
 	}
 

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -144,7 +144,7 @@ int preparse_dpf(
 	bool output_multiple_warning = true;
 	std::vector<std::string> xml_files;
 	bool read_more_xml_files = false;
-	for (int i=1; i<(*argc)-1; i++)
+	for (int i=1; i<(*argc); i++)
 	{
 		// wildcards for -xml2dlg are allowed (or multiple file names)
 		// - if more than one xml file is specified this way, they will end up in xml_files

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -1467,7 +1467,8 @@ void read_xml_filenames(
 std::vector<float> read_xml_genomes(
                                     char* xml_filename,
                                     float grid_spacing,
-                                    unsigned int &nrot
+                                    unsigned int &nrot,
+                                    bool store_axisangle
                                    )
 {
 	std::vector<float> result;
@@ -1557,11 +1558,13 @@ std::vector<float> read_xml_genomes(
 					error=9;
 					break;
 				}
-				theta=acos(*(gene+2)/sqrt((*gene)*(*gene)+(*(gene+1))*(*(gene+1))+(*(gene+2))*(*(gene+2))));
-				phi=atan2(*(gene+1),*gene);
-				*gene = phi / DEG_TO_RAD;
-				*(gene+1) = theta / DEG_TO_RAD;
-				*(gene+2) = genrot;
+				if(!store_axisangle){
+					theta=acos(*(gene+2)/sqrt((*gene)*(*gene)+(*(gene+1))*(*(gene+1))+(*(gene+2))*(*(gene+2))));
+					phi=atan2(*(gene+1),*gene);
+					*gene = phi / DEG_TO_RAD;
+					*(gene+1) = theta / DEG_TO_RAD;
+					*(gene+2) = genrot;
+				} else result[run_nr*GENOTYPE_LENGTH_IN_GLOBMEM-1] = genrot;
 				found_genome++;
 			} else{
 				error=10;

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -144,7 +144,7 @@ int preparse_dpf(
 	bool output_multiple_warning = true;
 	std::vector<std::string> xml_files;
 	bool read_more_xml_files = false;
-	for (int i=1; i<(*argc); i++)
+	for (int i=1; i<(*argc)-1+(read_more_xml_files); i++)
 	{
 		// wildcards for -xml2dlg are allowed (or multiple file names)
 		// - if more than one xml file is specified this way, they will end up in xml_files

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -169,6 +169,7 @@ int preparse_dpf(
 			mypars->load_xml = strdup(argv[i+1]);
 			read_more_xml_files = true;
 			mypars->xml2dlg = true;
+			mypars->xml_files = 1;
 		}
 	}
 	if (mypars->dpffile){
@@ -522,6 +523,7 @@ int preparse_dpf(
 		}
 	}
 	if(xml_files.size()>1){ // use filelist parameter list in case multiple xml files are converted
+		mypars->xml_files = xml_files.size();
 		for(unsigned i=0; i<xml_files.size(); i++){
 			// load_xml is the xml file from which the other parameters will be set
 			mypars->load_xml = strdup(xml_files[i].c_str());
@@ -812,7 +814,6 @@ int get_commandpars(
 	float tempfloat;
 	int   arg_recognized = 0;
 	int   arg_set = 1;
-	bool  skip_xml_files = false;
 	if(late_call){
 		// ------------------------------------------
 		// default values
@@ -843,13 +844,6 @@ int get_commandpars(
 	for (i=1; i<(*argc)-1; i+=2)
 	{
 		arg_recognized = 0;
-
-		// wildcards for -xml2dlg are allowed (or multiple file names)
-		// - if more than one xml file is specified this way, they will end up in xml_files
-		// the test below is to stop reading arguments as filenames when another argument starts with "-"
-		if (skip_xml_files && (argv[i][0]=='-')){
-			skip_xml_files = false;
-		} else arg_recognized = 1;
 
 		// Argument: number of energy evaluations. Must be a positive integer.
 		if (strcmp("-nev", argv[i]) == 0)
@@ -1145,7 +1139,19 @@ int get_commandpars(
 		if (strcmp("-xml2dlg", argv [i]) == 0)
 		{
 			arg_recognized = 1;
-			skip_xml_files = true;
+			i += mypars->xml_files-1; // skip ahead
+		}
+
+		// Argument: print dlg output to stdout instead of to a file
+		if (strcmp("-dlg2stdout", argv [i]) == 0)
+		{
+			arg_recognized = 1;
+			sscanf(argv [i+1], "%d", &tempint);
+
+			if (tempint == 0)
+				mypars->dlg2stdout = false;
+			else
+				mypars->dlg2stdout = true;
 		}
 
 		// Argument: number of pdb files to be generated.

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -621,7 +621,7 @@ int preparse_dpf(
 			filelist.mypars.push_back(*mypars);
 			filelist.mygrids.push_back(*mygrid);
 		}
-		printf("\n\n");
+		if(mypars->xml_files>100) printf("\n");
 		filelist.nfiles = mypars->xml_files;
 	} else{
 		filelist.nfiles = filelist.ligand_files.size();

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -545,8 +545,10 @@ int preparse_dpf(
 				printf("\nError: get_gridinfo failed with fld file specified in %s.\n",mypars->fldfile,mypars->load_xml);
 				return 1;
 			}
-			if(strcmp(prev_fld_file,mypars->fldfile) != 0)
-				filelist.fld_files.push_back(mypars->fldfile);
+			if(prev_fld_file){ // unfortunately, some strcmp implementation segfault with NULL as input
+				if(strcmp(prev_fld_file,mypars->fldfile) != 0)
+					filelist.fld_files.push_back(mypars->fldfile);
+			} else filelist.fld_files.push_back(mypars->fldfile);
 
 			// If more than one unique protein, cant do map preloading yet
 			if (filelist.fld_files.size()>1){

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -671,7 +671,8 @@ int get_filenames_and_ADcoeffs(
 		read_xml_filenames(mypars->load_xml,
 	                           mypars->fldfile,
 	                           mypars->ligandfile,
-	                           mypars->flexresfile);
+	                           mypars->flexresfile,
+	                           mypars->seed);
 	        mypars->pop_size=1;
 	}
 	
@@ -1404,7 +1405,8 @@ void read_xml_filenames(
                         char* xml_filename,
                         char* &grid_filename,
                         char* &ligand_filename,
-                        char* &flexres_filename
+                        char* &flexres_filename,
+                        uint32_t seed[3]
                        )
 {
 	std::ifstream file(xml_filename);
@@ -1418,6 +1420,7 @@ void read_xml_filenames(
 	std::string line;
 	char tmpstr[256];
 	size_t line_nr=0;
+	seed[0]=0; seed[1]=0; seed[2]=0;
 	while(std::getline(file, line)) {
 		line_nr++;
 		trim(line); // Remove leading and trailing whitespace
@@ -1446,6 +1449,12 @@ void read_xml_filenames(
 				break;
 			}
 			if(flexres_filename==NULL) flexres_filename=strdup(tmpstr);
+		}
+		if(line.find("<seed>")==0){
+			if(!sscanf(line.c_str(),"<seed>%d %d %d</seed>",&seed[0],&seed[1],&seed[2])){
+				error = 4;
+				break;
+			}
 		}
 	}
 	if(!grid_found || !ligand_found) error |= 8;

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -181,7 +181,7 @@ int main(int argc, char* argv[])
 		SimulationState sim_state;
 		int dev_nr = 0;
 #ifndef _WIN32
-	        timeval setup_timer, exec_timer, processing_timer;
+		timeval setup_timer, exec_timer, processing_timer;
 #else
 		double setup_timer, exec_timer, processing_timer;
 #endif
@@ -245,7 +245,7 @@ int main(int argc, char* argv[])
 					}
 				}
 			}
-
+			
 			// Starting Docking or loading results
 			if(mypars.xml2dlg){
 				start_timer(setup_timer);

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -371,7 +371,8 @@ int main(int argc, char* argv[])
 	printf("\nSavings from multithreading: %.3f sec",(total_setup_time+total_processing_time+total_exec_time) - seconds_since(time_start));
 	//if (filelist.preload_maps) printf("\nSavings from receptor reuse: %.3f sec * avg_maps_used/n_maps",receptor_reuse_time*n_files);
 	printf("\nIdle time of execution thread: %.3f sec",seconds_since(time_start) - total_exec_time);
-	if (get_profiles && filelist.used && !initial_pars.xml2dlg) profiler.write_profiles_to_file(filelist.filename);
+	if (get_profiles && filelist.used && !initial_pars.xml2dlg) // output profile with filelist name or dpf file name (depending on what is available)
+		profiler.write_profiles_to_file((filelist.filename!=NULL) ? filelist.filename : initial_pars.dpffile);
 #else
 	printf("\nProcessing time: %.3f sec",total_processing_time);
 #endif

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -104,7 +104,6 @@ int main(int argc, char* argv[])
 	// Setup master map set (one for now, nthreads-1 for general case)
 	std::vector<Map> all_maps;
 
-	bool xml2dlg = false;
 	int devnum=-1;
 	int nr_devices=initial_pars.devices_requested;
 	// Get device number to run on
@@ -217,8 +216,10 @@ int main(int argc, char* argv[])
 				// Keep in setup stage rather than moving to launch stage so a different job will be set up
 				printf("\n\nError in setup of Job #%d:\n", i_job+1);
 				if (filelist.used){
-					printf("(   Field file: %s )\n",  filelist.fld_files[i_job].c_str());
-					printf("(   Ligand file: %s )\n", filelist.ligand_files[i_job].c_str()); fflush(stdout);
+					printf("(   Grid map file: %s )\n",  mypars.fldfile);
+					printf("(   Ligand file: %s )\n", mypars.ligandfile); fflush(stdout);
+					if(mypars.flexresfile)
+						printf("(   Flexible residue: %s )\n", mypars.flexresfile); fflush(stdout);
 				}
 				err[i_job] = 1;
 				continue;

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -248,6 +248,7 @@ int main(int argc, char* argv[])
 
 			// Starting Docking or loading results
 			if(mypars.xml2dlg){
+				start_timer(setup_timer);
 				// allocating CPU memory for initial populations
 				mypars.output_xml = false;
 				unsigned int nr_genomes_loaded=0;
@@ -275,6 +276,7 @@ int main(int argc, char* argv[])
 				size_t size_evals_of_runs = mypars.num_of_runs*sizeof(int);
 				sim_state.cpu_evals_of_runs.resize(size_evals_of_runs);
 				memset(sim_state.cpu_evals_of_runs.data(), 0, size_evals_of_runs);
+				total_setup_time+=seconds_since(setup_timer);
 			} else{
 				int error_in_docking;
 				// Critical section to only let one thread access GPU at a time

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -71,7 +71,7 @@ inline void start_timer(T& time_start)
 int main(int argc, char* argv[])
 {
 	// Print version info
-	printf("AutoDock-GPU version: %s\n", VERSION);
+	printf("AutoDock-GPU version: %s\n\n", VERSION);
 	// Timer initializations
 #ifndef _WIN32
 	timeval time_start, idle_timer;
@@ -111,11 +111,14 @@ int main(int argc, char* argv[])
 			filelist.mypars[i].dlg2stdout = false;
 	}
 #endif
-	if(n_files>1){
-		if(initial_pars.xml2dlg)
-			printf("Converting %d xml files to dlg\n",n_files);
-		else
-			printf("Running %d docking calculations\n", n_files);
+	if(initial_pars.xml2dlg){
+		printf("Converting %d xml file",n_files);
+		if(n_files>1) printf("s");
+		printf(" to dlg\n");
+	} else{
+		printf("Running %d docking calculation",n_files);
+		if(n_files>1) printf("s");
+		printf("\n");
 	}
 	int pl_gridsize = preload_gridsize(filelist);
 

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
 				mypars.output_xml = false;
 				unsigned int nr_genomes_loaded=0;
 				unsigned int nrot;
-				sim_state.cpu_populations = read_xml_genomes(mypars.load_xml, mygrid.spacing, nrot);
+				sim_state.cpu_populations = read_xml_genomes(mypars.load_xml, mygrid.spacing, nrot, true);
 				if(nrot!=myligand_init.num_of_rotbonds){
 					printf("Error: XML genome contains %d rotatable bonds but current ligand has %d.\n",nrot,myligand_init.num_of_rotbonds);
 					exit(2);

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -287,8 +287,10 @@ int main(int argc, char* argv[])
 				{
 					printf("\nRunning Job #%d:\n", i_job+1);
 					if (filelist.used){
-						printf("   Fields from: %s\n",  filelist.fld_files[i_job].c_str());
-						printf("   Ligands from: %s\n", filelist.ligand_files[i_job].c_str()); fflush(stdout);
+						printf("   Grid map file: %s\n",  mypars.fldfile);
+						printf("   Ligand file: %s\n", mypars.ligandfile); fflush(stdout);
+						if(mypars.flexresfile)
+							printf("   Flexible residue: %s\n", mypars.flexresfile); fflush(stdout);
 					}
 					// End idling timer, start exec timer
 					sim_state.idle_time = seconds_since(idle_timer);
@@ -358,11 +360,10 @@ int main(int argc, char* argv[])
 	// Total time measurement
 	printf("\nRun time of entire job set (%d file%s): %.3f sec", n_files, n_files>1?"s":"", seconds_since(time_start));
 #ifdef USE_PIPELINE
-	printf("\n%.3f %.3f %.3f\n",total_setup_time,total_processing_time,total_exec_time);
 	printf("\nSavings from multithreading: %.3f sec",(total_setup_time+total_processing_time+total_exec_time) - seconds_since(time_start));
 	//if (filelist.preload_maps) printf("\nSavings from receptor reuse: %.3f sec * avg_maps_used/n_maps",receptor_reuse_time*n_files);
 	printf("\nIdle time of execution thread: %.3f sec",seconds_since(time_start) - total_exec_time);
-	if (get_profiles && filelist.used) profiler.write_profiles_to_file(filelist.filename);
+	if (get_profiles && filelist.used && !initial_pars.xml2dlg) profiler.write_profiles_to_file(filelist.filename);
 #else
 	printf("\nProcessing time: %.3f sec",total_processing_time);
 #endif

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -70,6 +70,9 @@ inline void start_timer(T& time_start)
 
 int main(int argc, char* argv[])
 {
+	// Print version info
+	printf("AutoDock-GPU version: %s\n", VERSION);
+
 	// Timer initializations
 #ifndef _WIN32
 	timeval time_start, idle_timer;
@@ -109,6 +112,8 @@ int main(int argc, char* argv[])
 	// Get device number to run on
 	for (unsigned int i=1; i<argc-1; i+=2)
 	{
+		if (strcmp("-xml2dlg", argv[i]) == 0)
+			i+=initial_pars.xml_files-1; // skip ahead in case there are multiple entries here
 		if (strcmp("-devnum", argv [i]) == 0)
 		{
 			unsigned int tempint;
@@ -147,9 +152,6 @@ int main(int argc, char* argv[])
 
 	// Error flag for each ligand
 	std::vector<int> err(n_files,0);
-
-	// Print version info
-	printf("AutoDock-GPU version: %s\n", VERSION);
 
 	if(!initial_pars.xml2dlg){
 		if(nr_devices==1){
@@ -325,6 +327,12 @@ int main(int argc, char* argv[])
 
 			// Post-processing
 			printf ("\n(Thread %d is processing Job #%d)\n",t_id,i_job+1); fflush(stdout);
+#ifdef USE_PIPELINE
+			if(mypars.dlg2stdout && (n_files>1)){
+				printf("\n(Thread %d, Job #%d: Parallel pipeline does not currently support dlg output to stdout, redirecting to file)\n",t_id,i_job+1); fflush(stdout);
+				mypars.dlg2stdout = false;
+			}
+#endif
 			start_timer(processing_timer);
 			process_result(&(mygrid), floatgrids.data(), &(mypars), &(myligand_init), &(myxrayligand), &argc,argv, sim_state);
 #ifdef USE_PIPELINE

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -558,9 +558,9 @@ parameters argc and argv:
 		// => e = 1/19*hm
 		// at hm = 50 M => e0 = 2.63 M where e becomes less than 95% (about 11 torsions)
 		mypars->num_of_energy_evals = (unsigned long)ceil(heur_evals*(float)mypars->heuristics_max/(mypars->heuristics_max+heur_evals));
-		printf("Using heuristics: (capped) number of evaluations set to %lu\n",mypars->num_of_energy_evals);
+		printf("    Using heuristics: (capped) number of evaluations set to %lu\n",mypars->num_of_energy_evals);
 		if (mypars->nev_provided && (mypars->num_of_energy_evals>nev)){
-			printf("Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
+			printf("    Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
 			mypars->num_of_energy_evals = nev;
 			profile.capped = true;
 		}
@@ -570,14 +570,14 @@ parameters argc and argv:
 		float min_frac = a/(1+cap_fraction*cap_fraction*(a/(a-1.0f)-1.0f))+1.0f-a;
 		min_as_evals = (unsigned long)ceil(mypars->num_of_energy_evals*min_frac)*mypars->num_of_runs;
 		if(cap_fraction<0.5f){
-			printf("Warning: The set number of evals is %.2f%% of the uncapped heuristics estimate of %lu evals.\n",cap_fraction*100.0f,heur_evals);
-			printf("         This means this docking may not be able to converge. Increasing ");
+			printf("    Warning: The set number of evals is %.2f%% of the uncapped heuristics estimate of %lu evals.\n",cap_fraction*100.0f,heur_evals);
+			printf("             This means this docking may not be able to converge. Increasing ");
 			if (mypars->nev_provided && (mypars->num_of_energy_evals>nev))
 				printf("-nev");
 			else
 				printf("-heurmax");
-			printf(" may improve\n         convergence but will also increase runtime.\n");
-			if(mypars->autostop) printf("         AutoStop will not stop before %.2f%% (%lu) of the set number of evaluations.\n",min_frac*100.0f,min_as_evals/mypars->num_of_runs);
+			printf(" may improve\n             convergence but will also increase runtime.\n");
+			if(mypars->autostop) printf("             AutoStop will not stop before %.2f%% (%lu) of the set number of evaluations.\n",min_frac*100.0f,min_as_evals/mypars->num_of_runs);
 		}
 	}
 	
@@ -592,13 +592,13 @@ parameters argc and argv:
 		strcpy(method_chosen,"ADAM (adam)");
 	}
 	else{
-		printf("Error: LS method %s is not (yet) supported in the Cuda version.\n",mypars->ls_method);
+		printf("\nError: LS method %s is not (yet) supported in the Cuda version.\n",mypars->ls_method);
 		exit(-1);
 	}
-	printf("Local-search chosen method is: %s\n", (cData.dockpars.lsearch_rate == 0.0f)? "GA" : method_chosen);
+	printf("    Local-search chosen method is: %s\n", (cData.dockpars.lsearch_rate == 0.0f)? "GA" : method_chosen);
 
 	if((mypars->initial_sw_generations>0) && (strcmp(mypars->ls_method, "sw") != 0))
-		printf("Using Solis-Wets (sw) for the first %d generations.\n",mypars->initial_sw_generations);
+		printf("    Using Solis-Wets (sw) for the first %d generations.\n",mypars->initial_sw_generations);
 
 	// Get profile for timing
 	profile.adadelta=(strcmp(mypars->ls_method, "ad")==0);

--- a/host/src/performdocking.cpp.OpenCL
+++ b/host/src/performdocking.cpp.OpenCL
@@ -633,9 +633,9 @@ parameters argc and argv:
 		// => e = 1/19*hm
 		// at hm = 50 M => e0 = 2.63 M where e becomes less than 95% (about 11 torsions)
 		mypars->num_of_energy_evals = (unsigned long)ceil(heur_evals*(float)mypars->heuristics_max/(mypars->heuristics_max+heur_evals));
-		printf("Using heuristics: (capped) number of evaluations set to %lu\n",mypars->num_of_energy_evals);
+		printf("    Using heuristics: (capped) number of evaluations set to %lu\n",mypars->num_of_energy_evals);
 		if (mypars->nev_provided && (mypars->num_of_energy_evals>nev)){
-			printf("Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
+			printf("    Overriding heuristics, setting number of evaluations to -nev = %lu instead.\n",nev);
 			mypars->num_of_energy_evals = nev;
 			profile.capped = true;
 		}
@@ -645,14 +645,14 @@ parameters argc and argv:
 		float min_frac = a/(1+cap_fraction*cap_fraction*(a/(a-1.0f)-1.0f))+1.0f-a;
 		min_as_evals = (unsigned long)ceil(mypars->num_of_energy_evals*min_frac)*mypars->num_of_runs;
 		if(cap_fraction<0.5f){
-			printf("Warning: The set number of evals is %.2f%% of the uncapped heuristics estimate of %lu evals.\n",cap_fraction*100.0f,heur_evals);
-			printf("         This means this docking may not be able to converge. Increasing ");
+			printf("    Warning: The set number of evals is %.2f%% of the uncapped heuristics estimate of %lu evals.\n",cap_fraction*100.0f,heur_evals);
+			printf("             This means this docking may not be able to converge. Increasing ");
 			if (mypars->nev_provided && (mypars->num_of_energy_evals>nev))
 				printf("-nev");
 			else
 				printf("-heurmax");
-			printf(" may improve\n         convergence but will also increase runtime.\n");
-			if(mypars->autostop) printf("         AutoStop will not stop before %.2f%% (%lu) of the set number of evaluations.\n",min_frac*100.0f,min_as_evals/mypars->num_of_runs);
+			printf(" may improve\n             convergence but will also increase runtime.\n");
+			if(mypars->autostop) printf("             AutoStop will not stop before %.2f%% (%lu) of the set number of evaluations.\n",min_frac*100.0f,min_as_evals/mypars->num_of_runs);
 		}
 	}
 	
@@ -670,13 +670,13 @@ parameters argc and argv:
 		strcpy(method_chosen,"ADADELTA (ad)");
 	}
 	else{
-		printf("Error: LS method %s is not (yet) supported in the OpenCL version.\n",mypars->ls_method);
+		printf("\nError: LS method %s is not (yet) supported in the OpenCL version.\n",mypars->ls_method);
 		exit(-1);
 	}
-	printf("Local-search chosen method is: %s\n", (dockpars.lsearch_rate == 0.0f)? "GA" : method_chosen);
+	printf("    Local-search chosen method is: %s\n", (dockpars.lsearch_rate == 0.0f)? "GA" : method_chosen);
 
 	if((mypars->initial_sw_generations>0) && (strcmp(mypars->ls_method, "sw") != 0))
-		printf("Using Solis-Wets (sw) for the first %d generations.\n",mypars->initial_sw_generations);
+		printf("    Using Solis-Wets (sw) for the first %d generations.\n",mypars->initial_sw_generations);
 
         // Get profile for timing
 	profile.adadelta=(strcmp(mypars->ls_method, "ad")==0);
@@ -698,7 +698,7 @@ parameters argc and argv:
 #endif
 
 	/*
-	// Addded for printing intracontributor_pairs (autodockdevpy)
+	// Added for printing intracontributor_pairs (autodockdevpy)
 	for (unsigned int intrapair_cnt=0; 
 			  intrapair_cnt<dockpars.num_of_intraE_contributors;
 			  intrapair_cnt++) {

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -2129,10 +2129,10 @@ float calc_intraE_f(
 
 	float vW, el, desolv;
 
-	vW = 0;
-	el = 0;
-	desolv = 0;
-	interflexE = 0;
+	vW = 0.0f;
+	el = 0.0f;
+	desolv = 0.0f;
+	interflexE = 0.0f;
 	
 	if (debug == 1)
 		printf("\n\n\nINTRAMOLECULAR ENERGY CALCULATION\n\n");
@@ -2178,12 +2178,12 @@ float calc_intraE_f(
 					smoothed_distance = dist - delta_distance;
 				}
 
-				distance_id = (int) floor((100*dist) + 0.5) - 1; // +0.5: rounding, -1: r_xx_table [0] corresponds to r=0.01
+				distance_id = (int) floor((100.0f*dist) + 0.5f) - 1; // +0.5: rounding, -1: r_xx_table [0] corresponds to r=0.01
 				if (distance_id < 0) {
 					distance_id = 0;
 				}
 
-				smoothed_distance_id = (int) floor((100*smoothed_distance) + 0.5) - 1; // +0.5: rounding, -1: r_xx_table [0] corresponds to r=0.01
+				smoothed_distance_id = (int) floor((100.0f*smoothed_distance) + 0.5f) - 1; // +0.5: rounding, -1: r_xx_table [0] corresponds to r=0.01
 				if (smoothed_distance_id < 0) {
 					smoothed_distance_id = 0;
 				}
@@ -2210,12 +2210,11 @@ float calc_intraE_f(
 				if (dist < dcutoff) // but only if the distance is less than distance cutoff value
 				{
 					pair_mod* pm = is_mod_pair(myligand->atom_types[type_id1], myligand->atom_types[type_id2], nr_mod_atype_pairs, mod_atype_pairs);
-					if (tables.is_HB [type_id1][type_id2] && !pm)	//H-bond
+					if (tables.is_HB [type_id1][type_id2] && !pm) //H-bond
 					{
 						vdW1 = myligand->VWpars_C [type_id1][type_id2]*tables.r_12_table [smoothed_distance_id];
 						vdW2 = myligand->VWpars_D [type_id1][type_id2]*tables.r_10_table [smoothed_distance_id];
-						if (debug == 1)
-							printf("H-bond interaction = ");
+						if (debug == 1) printf("H-bond interaction = ");
 					}
 					else // normal van der Waals or mod pair
 					{
@@ -2224,9 +2223,9 @@ float calc_intraE_f(
 						if(pm){
 							int m = (myligand->VWpars_exp [type_id1][type_id2] & 0xFF00) >> 8;
 							int n = (myligand->VWpars_exp [type_id1][type_id2] & 0xFF);
-							float dist = 0.01+smoothed_distance_id*0.01;
-							if(m!=12) r_A = 1/powf(dist,m);
-							if(n!=6) r_B = 1/powf(dist,n);
+							float dist = 0.01f + smoothed_distance_id*0.01f;
+							if(m!=12) r_A = powf(dist,-m);
+							if(n!=6) r_B = powf(dist,-n);
 						}
 						vdW1 = myligand->VWpars_A [type_id1][type_id2]*r_A;
 						vdW2 = myligand->VWpars_B [type_id1][type_id2]*r_B;

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -1422,7 +1422,7 @@ double calc_rmsd(
 
 	if (myligand_ref->true_ligand_atoms != myligand->true_ligand_atoms)
 	{
-		printf("Warning: RMSD can't be calculated, atom number mismatch!\n");
+		printf("Warning: RMSD can't be calculated, atom number mismatch %d (ref) vs. %d!\n",myligand_ref->true_ligand_atoms,myligand->true_ligand_atoms);
 		return 100000; // returning unreasonable value
 	}
 

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -182,6 +182,7 @@ void write_basic_info_dlg(
 {
 	int i;
 
+	if(mypars->xml2dlg && mypars->dlg2stdout) fprintf(fp, "\nXML2DLG: %s\n", mypars->load_xml);
 	fprintf(fp, "AutoDock-GPU version: %s\n\n", VERSION);
 
 	fprintf(fp, "**********************************************************\n");

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -977,7 +977,7 @@ void clusanal_gendlg(
 		if(mypars->dpffile)
 			fprintf(fp_xml, "\t<dpf>%s</dpf>\n",mypars->dpffile);
 		if(mypars->list_nr>1)
-			fprintf(fp_xml, "\t<list_nr>%s</list_nr>\n",mypars->list_nr);
+			fprintf(fp_xml, "\t<list_nr>%u</list_nr>\n",mypars->list_nr);
 		fprintf(fp_xml, "\t<grid>%s</grid>\n", mypars->fldfile);
 		fprintf(fp_xml, "\t<ligand>%s</ligand>\n", mypars->ligandfile);
 		if(mypars->flexresfile)

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -975,6 +975,8 @@ void clusanal_gendlg(
 		}
 		if(mypars->dpffile)
 			fprintf(fp_xml, "\t<dpf>%s</dpf>\n",mypars->dpffile);
+		if(mypars->list_nr>1)
+			fprintf(fp_xml, "\t<list_nr>%s</list_nr>\n",mypars->list_nr);
 		fprintf(fp_xml, "\t<grid>%s</grid>\n", mypars->fldfile);
 		fprintf(fp_xml, "\t<ligand>%s</ligand>\n", mypars->ligandfile);
 		if(mypars->flexresfile)

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -235,10 +235,12 @@ void write_basic_info_dlg(
 
 	fprintf(fp, "RMSD tolerance:                            %lfA\n\n", mypars->rmsd_tolerance);
 
-	fprintf(fp, "Program call in command line was:          ");
-	for (i=0; i<*argc; i++)
-		fprintf(fp, "%s ", argv [i]);
-	fprintf(fp, "\n\n\n");
+	if(!mypars->xml2dlg){ // This is necessary to avoid excruciatingly long command line outputs with wild cards (like *.xml)
+		fprintf(fp, "Program call in command line was:          ");
+		for (i=0; i<*argc; i++)
+			fprintf(fp, "%s ", argv [i]);
+		fprintf(fp, "\n\n\n");
+	}
 
 	// Writing out receptor parameters
 

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -421,9 +421,9 @@ void make_resfiles(
 					gen_new_pdbfile(mypars->ligandfile, "best.pdbqt", &temp_docked);
 			}
 
-		if (i < mypars->gen_pdbs)											//if it is necessary, making new pdbs for best entities
+		if (i < mypars->gen_pdbs) //if it is necessary, making new pdbs for best entities
 		{
-			sprintf(name_ext_start, "_docked_run%d_entity%d.pdbqt", run_cnt+1, i+1);	//name will be <original pdb filename>_docked_<number starting from 1>.pdb
+			sprintf(name_ext_start, "_docked_run%d_entity%d.pdbqt", run_cnt+1, i+1); //name will be <original pdb filename>_docked_<number starting from 1>.pdb
 			gen_new_pdbfile(mypars->ligandfile, temp_filename, &temp_docked);
 		}
 	}

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -357,8 +357,20 @@ void make_resfiles(
 	for (i=0; i<pop_size; i++)
 	{
 		temp_docked = *ligand_ref;
-
-		change_conform_f(&temp_docked, mygrid, final_population+i*GENOTYPE_LENGTH_IN_GLOBMEM, debug);
+		
+		if(mypars->xml2dlg){
+			double axisangle[4];
+			double genotype [ACTUAL_GENOTYPE_LENGTH];
+			for (unsigned int j=0; j<ACTUAL_GENOTYPE_LENGTH; j++)
+				genotype [j] = (final_population+i*GENOTYPE_LENGTH_IN_GLOBMEM)[j];
+			axisangle[0] = genotype[3];
+			axisangle[1] = genotype[4];
+			axisangle[2] = genotype[5];
+			axisangle[3] = (final_population+i*GENOTYPE_LENGTH_IN_GLOBMEM)[GENOTYPE_LENGTH_IN_GLOBMEM-1];
+			change_conform(&temp_docked, mygrid, genotype, axisangle, debug);
+		} else{
+			change_conform_f(&temp_docked, mygrid, final_population+i*GENOTYPE_LENGTH_IN_GLOBMEM, debug);
+		}
 		
 		// the map interaction of flex res atoms is stored in accurate_intraflexE[i]
 		accurate_interE[i] = calc_interE_f(mygrid, &temp_docked, grids, 0.0005, debug, accurate_intraflexE[i]);	//calculating the intermolecular energy

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -207,22 +207,25 @@ void write_basic_info_dlg(
 	if(mypars->seed[2]>0) fprintf(fp,", %u",mypars->seed[2]);
 	fprintf(fp, "\n");
 	fprintf(fp, "Number of runs:                            %lu\n", mypars->num_of_runs);
-	fprintf(fp, "Number of energy evaluations:              %ld\n", mypars->num_of_energy_evals);
-	fprintf(fp, "Number of generations:                     %ld\n", mypars->num_of_generations);
-	fprintf(fp, "Size of population:                        %ld\n", mypars->pop_size);
-	fprintf(fp, "Rate of crossover:                         %lf%%\n", (double) mypars->crossover_rate);
-	fprintf(fp, "Tournament selection probability limit:    %lf%%\n", (double) mypars->tournament_rate);
-	fprintf(fp, "Rate of mutation:                          %lf%%\n", (double) mypars->mutation_rate);
-	fprintf(fp, "Maximal allowed delta movement:            +/- %lfA\n", (double) mypars->abs_max_dmov*mygrid->spacing);
-	fprintf(fp, "Maximal allowed delta angle:               +/- %lf\n\n", (double) mypars->abs_max_dang);
+	
+	if(!mypars->xml2dlg){
+		fprintf(fp, "Number of energy evaluations:              %ld\n", mypars->num_of_energy_evals);
+		fprintf(fp, "Number of generations:                     %ld\n", mypars->num_of_generations);
+		fprintf(fp, "Size of population:                        %ld\n", mypars->pop_size);
+		fprintf(fp, "Rate of crossover:                         %lf%%\n", (double) mypars->crossover_rate);
+		fprintf(fp, "Tournament selection probability limit:    %lf%%\n", (double) mypars->tournament_rate);
+		fprintf(fp, "Rate of mutation:                          %lf%%\n", (double) mypars->mutation_rate);
+		fprintf(fp, "Maximal allowed delta movement:            +/- %lfA\n", (double) mypars->abs_max_dmov*mygrid->spacing);
+		fprintf(fp, "Maximal allowed delta angle:               +/- %lf\n\n", (double) mypars->abs_max_dang);
 
-	fprintf(fp, "Rate of local search:                      %lf%%\n", mypars->lsearch_rate);
+		fprintf(fp, "Rate of local search:                      %lf%%\n", mypars->lsearch_rate);
 
-	fprintf(fp, "Maximal number of local search iterations: %ld\n", mypars->max_num_of_iters);
-	fprintf(fp, "Rho lower bound:                           %lf\n", (double) mypars->rho_lower_bound);
-	fprintf(fp, "Spread of local search delta movement:     %lfA\n", (double) mypars->base_dmov_mul_sqrt3*mygrid->spacing/sqrt(3.0));
-	fprintf(fp, "Spread of local search delta angle:        %lf\n", (double) mypars->base_dang_mul_sqrt3/sqrt(3.0));
-	fprintf(fp, "Limit of consecutive successes/failures:   %ld\n\n", mypars->cons_limit);
+		fprintf(fp, "Maximal number of local search iterations: %ld\n", mypars->max_num_of_iters);
+		fprintf(fp, "Rho lower bound:                           %lf\n", (double) mypars->rho_lower_bound);
+		fprintf(fp, "Spread of local search delta movement:     %lfA\n", (double) mypars->base_dmov_mul_sqrt3*mygrid->spacing/sqrt(3.0));
+		fprintf(fp, "Spread of local search delta angle:        %lf\n", (double) mypars->base_dang_mul_sqrt3/sqrt(3.0));
+		fprintf(fp, "Limit of consecutive successes/failures:   %ld\n\n", mypars->cons_limit);
+	}
 
 		fprintf(fp, "Handle symmetry during clustering:         ");
 	if (mypars->handle_symmetry)
@@ -276,14 +279,16 @@ void write_basic_info_dlg(
 	fprintf(fp, "Number of atom types:                      %d\n", ligand_ref->num_of_atypes);
 	fprintf(fp, "\n\n");
 
-	fprintf(fp, "    DUMMY DATA (only for ADT-compatibility)\n");
-	fprintf(fp, "    ________________________\n\n\n");
-	fprintf(fp, "DPF> outlev 1\n");
-	fprintf(fp, "DPF> ga_run %lu\n", mypars->num_of_runs);
-	fprintf(fp, "DPF> fld %s.maps.fld\n", mygrid->receptor_name);
-	fprintf(fp, "DPF> move %s\n", mypars->ligandfile);
-	if(flexres) fprintf(fp, "DPF> flexres %s\n", mypars->flexresfile);
-	fprintf(fp, "\n\n");
+	if(!mypars->xml2dlg){
+		fprintf(fp, "    DUMMY DATA (only for ADT-compatibility)\n");
+		fprintf(fp, "    ________________________\n\n\n");
+		fprintf(fp, "DPF> outlev 1\n");
+		fprintf(fp, "DPF> ga_run %lu\n", mypars->num_of_runs);
+		fprintf(fp, "DPF> fld %s.maps.fld\n", mygrid->receptor_name);
+		fprintf(fp, "DPF> move %s\n", mypars->ligandfile);
+		if(flexres) fprintf(fp, "DPF> flexres %s\n", mypars->flexresfile);
+		fprintf(fp, "\n\n");
+	}
 }
 
 void make_resfiles(
@@ -647,11 +652,13 @@ void clusanal_gendlg(
 
 	write_basic_info_dlg(fp, ligand_ref, mypars, mygrid, argc, argv);
 
-	fprintf(fp, "           COUNTER STATES           \n");
-	fprintf(fp, "___________________________________\n\n");
-	fprintf(fp, "Number of energy evaluations performed:    %lu\n", evals_performed);
-	fprintf(fp, "Number of generations used:                %lu\n", generations_used);
-	fprintf(fp, "\n\n");
+	if(!mypars->xml2dlg){
+		fprintf(fp, "           COUNTER STATES           \n");
+		fprintf(fp, "___________________________________\n\n");
+		fprintf(fp, "Number of energy evaluations performed:    %lu\n", evals_performed);
+		fprintf(fp, "Number of generations used:                %lu\n", generations_used);
+		fprintf(fp, "\n\n");
+	}
 
 	// writing input pdbqt file
 

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -357,16 +357,18 @@ int setup(
 	get_commandpars(&argc, argv, &(mygrid.spacing), &mypars);
 
 	// command-line specified resname with more than one file
-	if ((orig_resn!=mypars.resname) && (filelist.nfiles>1)){ // add an index to existing name distinguish the files
-		char* tmp = strdup(mypars.resname);
-		char* nrtmp = strdup(std::to_string(i_file+1).c_str());
-		if(mypars.resname) free(mypars.resname);
-		mypars.resname = (char*)malloc((strlen(tmp)+strlen(nrtmp)+2)*sizeof(char));
-		strcpy(mypars.resname, tmp);
-		strcat(mypars.resname,"_");
-		strcat(mypars.resname, nrtmp);
-		free(tmp);
-		free(nrtmp);
+	if (!mypars.xml2dlg){ // if the user specified an xml file, that's the one we want to use
+		if ((orig_resn!=mypars.resname) && (filelist.nfiles>1)){ // add an index to existing name distinguish the files
+			char* tmp = strdup(mypars.resname);
+			char* nrtmp = strdup(std::to_string(i_file+1).c_str());
+			if(mypars.resname) free(mypars.resname);
+			mypars.resname = (char*)malloc((strlen(tmp)+strlen(nrtmp)+2)*sizeof(char));
+			strcpy(mypars.resname, tmp);
+			strcat(mypars.resname,"_");
+			strcat(mypars.resname, nrtmp);
+			free(tmp);
+			free(nrtmp);
+		}
 	}
 
 	Gridinfo mydummygrid;

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -72,6 +72,9 @@ int setup(
 	//------------------------------------------------------------
 	for (unsigned int i=1; i<argc-1; i+=2)
 	{
+		if (strcmp("-xml2dlg", argv[i]) == 0)
+			i+=mypars.xml_files-1; // skip ahead in case there are multiple entries here
+
 		// ----------------------------------
 		// Argument: Use individual maps for CG-G0 instead of the same one
 		if (strcmp("-cgmaps", argv [i]) == 0)


### PR DESCRIPTION
This PR adds a command line parameter, `-xml2dlg <xml filename>`, to convert AD-GPU's XML file output into our DLG file format (minus the data that isn't stored in the XML). I tested with multiple outputs but would like some more tests of its functionality.

The code itself lives purely in CPU-land and should not change any calculations - but since it is intertwined with parameter read-in and the pipeline code we should test this functionality as well to make sure these things work well still.

I will eventually add code to either the dpf file import or the filelist to allow multiple xml files to be converted.