### PR TITLE
Added option -dlgoutput (default: 1) to control output of dlg file.

### DIFF
--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -134,7 +134,8 @@ typedef struct _Dockpars
 	float                     adam_beta1                      = 0.9f;
 	float                     adam_beta2                      = 0.999f;
 	float                     adam_epsilon                    = 1.0e-8f;
-	bool                      output_xml                      = true; // xml output file will be generated
+	bool                      output_dlg                      = true; // dlg output file will be generated (by default)
+	bool                      output_xml                      = true; // xml output file will be generated (by default)
 } Dockpars;
 
 inline bool add_deriv_atype(

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -1545,6 +1545,10 @@ int get_commandpars(
 				mypars->output_dlg = false;
 			else
 				mypars->output_dlg = true;
+			if(!mypars->output_dlg && (mypars->xml2dlg || mypars->dlg2stdout)){
+				printf("Note: Value of -dlgoutput ignored. Arguments -xml2dlg or -dlg2stdout require dlg output.\n");
+				mypars->output_dlg = true;
+			}
 		}
 
 		// Argument: choose wether to output XML or not

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -1533,8 +1533,22 @@ int get_commandpars(
 				printf("Warning: value of -rmstol argument ignored. Value must be a double greater than 0.\n");
 		}
 
+		// Argument: choose wether to output DLG or not
+		// If the value is 1, DLG output will be generated
+		// DLG output won't be generated if 0 is specified
+		if (strcmp("-dlgoutput", argv [i]) == 0)
+		{
+			arg_recognized = 1;
+			sscanf(argv [i+1], "%d", &tempint);
+			
+			if (tempint == 0)
+				mypars->output_dlg = false;
+			else
+				mypars->output_dlg = true;
+		}
+
 		// Argument: choose wether to output XML or not
-		// If the value is 1, XML output will still be generated
+		// If the value is 1, XML output will be generated
 		// XML output won't be generated if 0 is specified
 		if (strcmp("-xmloutput", argv [i]) == 0)
 		{

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -667,11 +667,8 @@ void clusanal_gendlg(
 			fp = fopen(report_file_name, "w");
 			free(report_file_name);
 		}
-	}
 
-	// writing basic info
-
-	if(mypars->output_dlg){
+		// writing basic info
 		write_basic_info_dlg(fp, ligand_ref, mypars, mygrid, argc, argv);
 
 		if(!mypars->xml2dlg){


### PR DESCRIPTION
This PR adds the -dlgoutput command line option which controls wether a dlg file is ouput (default: yes) or not.

Currently there is no test wether when no dlg is output the XML output should automatically be generated. Please comment if you think that is needed or not. I am leaning towards not adding that as although it sounds counter-productive to not store a docking result at all i can imagine scenarios for which this may make sense (benchmarking, debugging, quick energy ballpark calculations). And since the default is to output both a dlg and an xml file it would be a deliberate choice on the user's side to not output anything :-)