### PR TITLE
Fix for memory double freeing and wrong Cuda device in certain cases

### DIFF
--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -477,6 +477,9 @@ int main(int argc, char* argv[])
 				if(mypars.resname) free(mypars.resname);
 			}
 		} // end of for loop
+#ifdef USE_PIPELINE
+		#pragma omp single
+#endif
 		if(!filelist.used){
 			// Clean up memory dynamically allocated to not leak
 			mypars.receptor_atoms.clear();
@@ -488,6 +491,7 @@ int main(int argc, char* argv[])
 		}
 	} // end of parallel section
 	if(initial_pars.xml2dlg && !initial_pars.dlg2stdout && (n_files>100)) printf("\n\n"); // finish progress bar
+
 	
 #ifndef _WIN32
 	// Total time measurement

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -119,16 +119,12 @@ void setup_gpu_for_docking(
                            GpuTempData& tData
                           )
 {
-	cudaError_t status;
-	if(cData.devnum<-1){
-		status = cudaSetDevice(cData.devid);
-		return; // device already setup
-	}
+	if(cData.devnum<-1) return; // device already setup
 	auto const t0 = std::chrono::steady_clock::now();
 
 	// Initialize CUDA
 	int gpuCount=0;
-	status = cudaGetDeviceCount(&gpuCount);
+	cudaError_t status = cudaGetDeviceCount(&gpuCount);
 	RTERROR(status, "cudaGetDeviceCount failed");
 	if (gpuCount == 0)
 	{
@@ -316,7 +312,7 @@ parameters argc and argv:
 	if(output!=NULL) outbuf = (char*)malloc(256*sizeof(char));
 
 	auto const t1 = std::chrono::steady_clock::now();
-	cudaError_t status;
+	cudaError_t status = cudaSetDevice(cData.devid); // make sure we're on the correct device
 
 	Liganddata myligand_reference;
 
@@ -590,21 +586,6 @@ parameters argc and argv:
 	unsigned int ite_cnt = 0;
 #endif
 
-	/*
-	// Added for printing intracontributor_pairs (autodockdevpy)
-	for (unsigned int intrapair_cnt=0; 
-			  intrapair_cnt<dockpars.num_of_intraE_contributors;
-			  intrapair_cnt++) {
-		if (intrapair_cnt == 0) {
-			para_printf("%-10s %-10s %-10s\n", "#pair", "#atom1", "#atom2");
-		}
-
-		para_printf ("%-10u %-10u %-10u\n", intrapair_cnt,
-		        KerConst.intraE_contributors_const[3*intrapair_cnt],
-		        KerConst.intraE_contributors_const[3*intrapair_cnt+1]);
-	}
-	*/
-
 	// Kernel1
 	uint32_t kernel1_gxsize = blocksPerGridForEachEntity;
 	uint32_t kernel1_lxsize = threadsPerBlock;
@@ -694,7 +675,6 @@ parameters argc and argv:
 		cudaDeviceSynchronize();
 	#endif
 	gpu_calc_initpop(kernel1_gxsize, kernel1_lxsize, pMem_conformations_current, pMem_energies_current);
-	//runKernel1D(command_queue,kernel1,kernel1_gxsize,kernel1_lxsize,&time_start_kernel,&time_end_kernel);
 	#ifdef DOCK_DEBUG
 		cudaDeviceSynchronize();
 		para_printf("%15s" ," ... Finished\n");fflush(stdout);
@@ -705,7 +685,6 @@ parameters argc and argv:
 	#ifdef DOCK_DEBUG
 		para_printf("%-25s", "\tK_EVAL");fflush(stdout);
 	#endif
-	//runKernel1D(command_queue,kernel2,kernel2_gxsize,kernel2_lxsize,&time_start_kernel,&time_end_kernel);
 	gpu_sum_evals(kernel2_gxsize, kernel2_lxsize);
 	#ifdef DOCK_DEBUG
 		cudaDeviceSynchronize();


### PR DESCRIPTION
This PR contains a small fix for annoying segfaults caused by double freeing in a rare case where multi-threaded code is run with a single ligand.

Also addresses the bug reported in #152 which was caused by the wrong Cuda device being selected during multi-threaded runs with only one device when more than one is present in the system.