### PR TITLE
Covalent docking, flex res specification in filelist, and bugfix for more than one ligand

### DIFF
--- a/cuda/calcenergy.cu
+++ b/cuda/calcenergy.cu
@@ -142,22 +142,24 @@ __device__ void gpu_calc_energy(
 
 	// General rotation moving vector
 	float4 genrot_movingvec;
-	genrot_movingvec.x = pGenotype[0];
-	genrot_movingvec.y = pGenotype[1];
-	genrot_movingvec.z = pGenotype[2];
-	genrot_movingvec.w = 0.0f;
 	// Convert orientation genes from sex. to radians
 	float phi         = pGenotype[3] * DEG_TO_RAD;
 	float theta       = pGenotype[4] * DEG_TO_RAD;
 	float genrotangle = pGenotype[5] * DEG_TO_RAD;
 
 	float4 genrot_unitvec;
-	float sin_angle = sin(theta);
-	float s2 = sin(genrotangle * 0.5f);
-	genrot_unitvec.x = s2*sin_angle*cos(phi);
-	genrot_unitvec.y = s2*sin_angle*sin(phi);
-	genrot_unitvec.z = s2*cos(theta);
-	genrot_unitvec.w = cos(genrotangle*0.5f);
+	if(cData.dockpars.true_ligand_atoms){
+		genrot_movingvec.x = pGenotype[0];
+		genrot_movingvec.y = pGenotype[1];
+		genrot_movingvec.z = pGenotype[2];
+		genrot_movingvec.w = 0.0f;
+		float sin_angle = sin(theta);
+		float s2 = sin(genrotangle * 0.5f);
+		genrot_unitvec.x = s2*sin_angle*cos(phi);
+		genrot_unitvec.y = s2*sin_angle*sin(phi);
+		genrot_unitvec.z = s2*cos(theta);
+		genrot_unitvec.w = cos(genrotangle*0.5f);
+	}
 
 	uint g1 = cData.dockpars.gridsize_x;
 	uint g2 = cData.dockpars.gridsize_x_times_y;

--- a/cuda/kernel3.cu
+++ b/cuda/kernel3.cu
@@ -104,6 +104,8 @@ gpu_perform_LS_kernel(
 	__syncthreads();
 	
 
+	uint32_t gene_start = (cData.dockpars.true_ligand_atoms==0)*6;
+
 #ifdef SWAT3
 	float lig_scale = 1.0f/sqrt((float)cData.dockpars.num_of_atoms);
 	float gene_scale = 1.0f/sqrt((float)cData.dockpars.num_of_genes);
@@ -111,7 +113,7 @@ gpu_perform_LS_kernel(
 	while ((iteration_cnt < cData.dockpars.max_num_of_iters) && (rho > cData.dockpars.rho_lower_bound))
 	{
 		// New random deviate
-		for (uint32_t gene_counter = threadIdx.x;
+		for (uint32_t gene_counter = threadIdx.x+gene_start;
 		              gene_counter < cData.dockpars.num_of_genes;
 		              gene_counter+= blockDim.x)
 		{
@@ -145,7 +147,7 @@ gpu_perform_LS_kernel(
 		}
 
 		// Generating new genotype candidate
-		for (uint32_t gene_counter = threadIdx.x;
+		for (uint32_t gene_counter = threadIdx.x+gene_start;
 		              gene_counter < cData.dockpars.num_of_genes;
 		              gene_counter+= blockDim.x)
 		{
@@ -172,7 +174,7 @@ gpu_perform_LS_kernel(
 
 		if (candidate_energy < offspring_energy)	// If candidate is better, success
 		{
-			for (uint32_t gene_counter = threadIdx.x;
+			for (uint32_t gene_counter = threadIdx.x+gene_start;
 			              gene_counter < cData.dockpars.num_of_genes;
 			              gene_counter+= blockDim.x)
 			{
@@ -196,7 +198,7 @@ gpu_perform_LS_kernel(
 		else // If candidate is worse, check the opposite direction
 		{
 			// Generating the other genotype candidate
-			for (uint32_t gene_counter = threadIdx.x;
+			for (uint32_t gene_counter = threadIdx.x+gene_start;
 			              gene_counter < cData.dockpars.num_of_genes;
 			              gene_counter+= blockDim.x)
 			{
@@ -229,7 +231,7 @@ gpu_perform_LS_kernel(
 
 			if (candidate_energy < offspring_energy) // If candidate is better, success
 			{
-				for (uint32_t gene_counter = threadIdx.x;
+				for (uint32_t gene_counter = threadIdx.x+gene_start;
 				              gene_counter < cData.dockpars.num_of_genes;
 				              gene_counter+= blockDim.x)
 				{
@@ -241,7 +243,7 @@ gpu_perform_LS_kernel(
 
 				// Work-item 0 will overwrite the shared variables
 				// used in the previous if condition
-							__syncthreads();
+				__syncthreads();
 
 				if (threadIdx.x == 0)
 				{
@@ -252,7 +254,7 @@ gpu_perform_LS_kernel(
 			}
 			else	// Failure in both directions
 			{
-				for (uint32_t gene_counter = threadIdx.x;
+				for (uint32_t gene_counter = threadIdx.x+gene_start;
 				              gene_counter < cData.dockpars.num_of_genes;
 				              gene_counter+= blockDim.x)
 				{
@@ -294,7 +296,7 @@ gpu_perform_LS_kernel(
 
 	// Mapping torsion angles and writing out results
 	offset = (run_id*cData.dockpars.pop_size+entity_id)*GENOTYPE_LENGTH_IN_GLOBMEM;
-	for (uint32_t gene_counter = threadIdx.x;
+	for (uint32_t gene_counter = threadIdx.x+gene_start;
 	              gene_counter < cData.dockpars.num_of_genes;
 	              gene_counter+= blockDim.x)
 	{

--- a/device/calcMergedEneGra.cl
+++ b/device/calcMergedEneGra.cl
@@ -140,10 +140,6 @@ void gpu_calc_energrad(
 
 	// General rotation moving vector
 	float4 genrot_movingvec;
-	genrot_movingvec.x = genotype[0];
-	genrot_movingvec.y = genotype[1];
-	genrot_movingvec.z = genotype[2];
-	genrot_movingvec.w = 0.0f;
 
 	// Convert orientation genes from sex. to radians
 	float phi         = genotype[3] * DEG_TO_RAD;
@@ -151,13 +147,20 @@ void gpu_calc_energrad(
 	float genrotangle = genotype[5] * DEG_TO_RAD;
 
 	float4 genrot_unitvec;
-	float sin_angle = native_sin(theta);
-	float s2 = native_sin(genrotangle*0.5f);
-	genrot_unitvec.x = s2*sin_angle*native_cos(phi);
-	genrot_unitvec.y = s2*sin_angle*native_sin(phi);
-	genrot_unitvec.z = s2*native_cos(theta);
-	genrot_unitvec.w = native_cos(genrotangle*0.5f);
-	float is_theta_gt_pi = 1.0f-2.0f*(float)(sin_angle < 0.0f);
+	float is_theta_gt_pi;
+	if(dockpars_true_ligand_atoms){
+		genrot_movingvec.x = genotype[0];
+		genrot_movingvec.y = genotype[1];
+		genrot_movingvec.z = genotype[2];
+		genrot_movingvec.w = 0.0f;
+		float sin_angle = native_sin(theta);
+		float s2 = native_sin(genrotangle*0.5f);
+		genrot_unitvec.x = s2*sin_angle*native_cos(phi);
+		genrot_unitvec.y = s2*sin_angle*native_sin(phi);
+		genrot_unitvec.z = s2*native_cos(theta);
+		genrot_unitvec.w = native_cos(genrotangle*0.5f);
+		is_theta_gt_pi = 1.0f-2.0f*(float)(sin_angle < 0.0f);
+	}
 
 	uint g1 = dockpars_gridsize_x;
 	uint g2 = dockpars_gridsize_x_times_y;
@@ -670,27 +673,29 @@ void gpu_calc_energrad(
 		// their corresponding gradients were calculated in the space
 		// where these genes are in Angstrom,
 		// but AutoDock-GPU translational genes are within in grids
+		if(dockpars_true_ligand_atoms){
 #ifdef FLOAT_GRADIENTS
-		gradient_genotype[0] = accumulator_x[0] * dockpars_grid_spacing;
-		gradient_genotype[1] = accumulator_y[0] * dockpars_grid_spacing;
-		gradient_genotype[2] = accumulator_z[0] * dockpars_grid_spacing;
-		#if defined (PRINT_GRAD_TRANSLATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("gradient_x:%f\n", gradient_genotype [0]);
-		printf("gradient_y:%f\n", gradient_genotype [1]);
-		printf("gradient_z:%f\n", gradient_genotype [2]);
-		#endif
+			gradient_genotype[0] = accumulator_x[0] * dockpars_grid_spacing;
+			gradient_genotype[1] = accumulator_y[0] * dockpars_grid_spacing;
+			gradient_genotype[2] = accumulator_z[0] * dockpars_grid_spacing;
+			#if defined (PRINT_GRAD_TRANSLATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("gradient_x:%f\n", gradient_genotype [0]);
+			printf("gradient_y:%f\n", gradient_genotype [1]);
+			printf("gradient_z:%f\n", gradient_genotype [2]);
+			#endif
 #else
-		i_gradient_genotype[0] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * accumulator_x[0] * dockpars_grid_spacing)));
-		i_gradient_genotype[1] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * accumulator_y[0] * dockpars_grid_spacing)));
-		i_gradient_genotype[2] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * accumulator_z[0] * dockpars_grid_spacing)));
-		#if defined (PRINT_GRAD_TRANSLATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("i_gradient_x:%f\n", i_gradient_genotype [0]);
-		printf("i_gradient_y:%f\n", i_gradient_genotype [1]);
-		printf("i_gradient_z:%f\n", i_gradient_genotype [2]);
-		#endif
+			i_gradient_genotype[0] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * accumulator_x[0] * dockpars_grid_spacing)));
+			i_gradient_genotype[1] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * accumulator_y[0] * dockpars_grid_spacing)));
+			i_gradient_genotype[2] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * accumulator_z[0] * dockpars_grid_spacing)));
+			#if defined (PRINT_GRAD_TRANSLATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("i_gradient_x:%f\n", i_gradient_genotype [0]);
+			printf("i_gradient_y:%f\n", i_gradient_genotype [1]);
+			printf("i_gradient_z:%f\n", i_gradient_genotype [2]);
+			#endif
 #endif
+		}
 	}
 
 	// ------------------------------------------
@@ -706,232 +711,234 @@ void gpu_calc_energrad(
 	// Derived from autodockdev/motions.py/_get_cube3_gradient()
 	// ------------------------------------------
 
-	accumulator_x[tidx] = 0.0f;
-	accumulator_y[tidx] = 0.0f;
-	accumulator_z[tidx] = 0.0f;
-	for ( int atom_cnt = tidx;
-	          atom_cnt < dockpars_true_ligand_atoms;
-	          atom_cnt+= NUM_OF_THREADS_PER_BLOCK)
-	{
-		float4 r = (calc_coords[atom_cnt] - genrot_movingvec) * dockpars_grid_spacing;
-		// Re-using "gradient_inter_*" for total gradient (inter+intra)
-		float4 force;
+	if(dockpars_true_ligand_atoms){
+		accumulator_x[tidx] = 0.0f;
+		accumulator_y[tidx] = 0.0f;
+		accumulator_z[tidx] = 0.0f;
+		for ( int atom_cnt = tidx;
+		          atom_cnt < dockpars_true_ligand_atoms;
+		          atom_cnt+= NUM_OF_THREADS_PER_BLOCK)
+		{
+			float4 r = (calc_coords[atom_cnt] - genrot_movingvec) * dockpars_grid_spacing;
+			// Re-using "gradient_inter_*" for total gradient (inter+intra)
+			float4 force;
 #ifdef FLOAT_GRADIENTS
-		force.x = gradient_x[atom_cnt];
-		force.y = gradient_y[atom_cnt];
-		force.z = gradient_z[atom_cnt];
+			force.x = gradient_x[atom_cnt];
+			force.y = gradient_y[atom_cnt];
+			force.z = gradient_z[atom_cnt];
 #else
-		force.x = ONEOVERTERMSCALE * gradient_x[atom_cnt];
-		force.y = ONEOVERTERMSCALE * gradient_y[atom_cnt];
-		force.z = ONEOVERTERMSCALE * gradient_z[atom_cnt];
+			force.x = ONEOVERTERMSCALE * gradient_x[atom_cnt];
+			force.y = ONEOVERTERMSCALE * gradient_y[atom_cnt];
+			force.z = ONEOVERTERMSCALE * gradient_z[atom_cnt];
 #endif
-		force.w = 0.0f;
-		float4 torque_rot = cross(r, force);
-		accumulator_x[tidx] += torque_rot.x;
-		accumulator_y[tidx] += torque_rot.y;
-		accumulator_z[tidx] += torque_rot.z;
-	}
-	// do a reduction over the total gradient containing prepared "gradient_intra_*" values
-	for ( int off=NUM_OF_THREADS_PER_BLOCK>>1; off>0; off >>= 1)
-	{
-		barrier(CLK_LOCAL_MEM_FENCE);
-		if (tidx < off)
-		{
-			accumulator_x[tidx] += accumulator_x[tidx+off];
-			accumulator_y[tidx] += accumulator_y[tidx+off];
-			accumulator_z[tidx] += accumulator_z[tidx+off];
+			force.w = 0.0f;
+			float4 torque_rot = cross(r, force);
+			accumulator_x[tidx] += torque_rot.x;
+			accumulator_y[tidx] += torque_rot.y;
+			accumulator_z[tidx] += torque_rot.z;
 		}
-	}
-	if (tidx == 0) {
-		float4 torque_rot;
-		torque_rot.x = accumulator_x[0];
-		torque_rot.y = accumulator_y[0];
-		torque_rot.z = accumulator_z[0];
-
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-20s %-10.6f %-10.6f %-10.6f\n", "final torque: ", torque_rot.x, torque_rot.y, torque_rot.z);
-		#endif
-
-		// Derived from rotation.py/axisangle_to_q()
-		// genes[3:7] = rotation.axisangle_to_q(torque, rad)
-		float torque_length = native_sqrt(torque_rot.x*torque_rot.x+torque_rot.y*torque_rot.y+torque_rot.z*torque_rot.z);
-		torque_length += (torque_length<1e-20f)*1e-20f;
-		
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-20s %-10.6f\n", "torque length: ", torque_length);
-		#endif
-
-		// Finding the quaternion that performs
-		// the infinitesimal rotation around torque axis
-		float4 quat_torque = native_divide(torque_rot * SIN_HALF_INFINITESIMAL_RADIAN, torque_length);
-		quat_torque.w = COS_HALF_INFINITESIMAL_RADIAN;
-
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-20s %-10.6f\n", "INFINITESIMAL_RADIAN: ", INFINITESIMAL_RADIAN);
-		printf("%-20s %-10.6f %-10.6f %-10.6f %-10.6f\n", "quat_torque (w,x,y,z): ", quat_torque.w, quat_torque.x, quat_torque.y, quat_torque.z);
-		#endif
-
-		// Converting quaternion gradients into orientation gradients 
-		// Derived from autodockdev/motion.py/_get_cube3_gradient
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-30s %-10.6f %-10.6f %-10.6f %-10.6f\n", "current_q (w,x,y,z): ", genrot_unitvec.w, genrot_unitvec.x, genrot_unitvec.y, genrot_unitvec.z);
-		#endif
-
-		// This is where we want to be in quaternion space
-		// target_q = rotation.q_mult(q, current_q)
-		float4 target_q = quaternion_multiply(quat_torque, genrot_unitvec);
-
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-30s %-10.6f %-10.6f %-10.6f %-10.6f\n", "target_q (w,x,y,z): ", target_q.w, target_q.x, target_q.y, target_q.z);
-		#endif
-
-		// This is where we are in the orientation axis-angle space
-		// Equivalent to "current_oclacube" in autodockdev/motions.py
-		float current_phi      = fmod_pi2(PI_TIMES_2 + phi);
-		float current_theta    = fmod_pi2(PI_TIMES_2 + theta);
-		float current_rotangle = fmod_pi2(PI_TIMES_2 + genrotangle);
-
-		// This is where we want to be in the orientation axis-angle space
-		float target_phi, target_theta, target_rotangle;
-
-		// target_oclacube = quaternion_to_oclacube(target_q, theta_larger_than_pi)
-		// Derived from autodockdev/motions.py/quaternion_to_oclacube()
-		// In our terms means quaternion_to_oclacube(target_q{w|x|y|z}, theta_larger_than_pi)
-		target_rotangle = 2.0f * fast_acos(target_q.w); // = 2.0f * ang;
-		float inv_sin_ang = native_rsqrt(1.0f-target_q.w*target_q.w); // = 1.0/native_sin(ang);
-
-		target_theta = PI_TIMES_2 + is_theta_gt_pi * fast_acos( target_q.z * inv_sin_ang );
-		target_phi   = fmod_pi2((atan2( is_theta_gt_pi*target_q.y, is_theta_gt_pi*target_q.x) + PI_TIMES_2));
-
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-30s %-10.6f %-10.6f %-10.6f\n", "target_axisangle (1,2,3): ", target_phi, target_theta, target_rotangle);
-		#endif
-		
-		// The infinitesimal rotation will produce an infinitesimal displacement
-		// in shoemake space. This is to guarantee that the direction of
-		// the displacement in shoemake space is not distorted.
-		// The correct amount of displacement in shoemake space is obtained
-		// by multiplying the infinitesimal displacement by shoemake_scaling:
-		float orientation_scaling = torque_length * INV_INFINITESIMAL_RADIAN;
-
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-30s %-10.6f\n", "orientation_scaling: ", orientation_scaling);
-		#endif
-
-		// Derivates in cube3
-		float grad_phi, grad_theta, grad_rotangle;
-		grad_phi      = orientation_scaling * (fmod_pi2(target_phi      - current_phi      + PI_FLOAT) - PI_FLOAT);
-		grad_theta    = orientation_scaling * (fmod_pi2(target_theta    - current_theta    + PI_FLOAT) - PI_FLOAT);
-		grad_rotangle = orientation_scaling * (fmod_pi2(target_rotangle - current_rotangle + PI_FLOAT) - PI_FLOAT);
-
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-30s \n", "grad_axisangle (1,2,3) - before empirical scaling: ");
-		printf("%-13s %-13s %-13s \n", "grad_phi", "grad_theta", "grad_rotangle");
-		printf("%-13.6f %-13.6f %-13.6f\n", grad_phi, grad_theta, grad_rotangle);
-		#endif
-
-		// Correcting theta gradients interpolating 
-		// values from correction look-up-tables
-		// (X0,Y0) and (X1,Y1) are known points
-		// How to find the Y value in the straight line between Y0 and Y1,
-		// corresponding to a certain X?
-		/*
-			| dependence_on_theta_const
-			| dependence_on_rotangle_const
-			|
-			|
-			|                        Y1
-			|
-			|             Y=?
-			|    Y0
-			|_________________________________ angle_const
-			     X0         X        X1
-		*/
-
-		// Finding the index-position of "grad_delta" in the "angle_const" array
-		//uint index_theta    = floor(native_divide(current_theta    - angle_const[0], angle_delta));
-		//uint index_rotangle = floor(native_divide(current_rotangle - angle_const[0], angle_delta));
-		uint index_theta    = floor((current_theta    - angle_const[0]) * inv_angle_delta);
-		uint index_rotangle = floor((current_rotangle - angle_const[0]) * inv_angle_delta);
-
-		// Interpolating theta values
-		// X0 -> index - 1
-		// X1 -> index + 1
-		// Expresed as weighted average:
-		// Y = [Y0 * ((X1 - X) / (X1-X0))] +  [Y1 * ((X - X0) / (X1-X0))]
-		// Simplified for GPU (less terms):
-		// Y = [Y0 * (X1 - X) + Y1 * (X - X0)] / (X1 - X0)
-		// Taking advantage of constant:
-		// Y = [Y0 * (X1 - X) + Y1 * (X - X0)] * inv_angle_delta
-
-		float X0, Y0;
-		float X1, Y1;
-		float dependence_on_theta; //Y = dependence_on_theta
-
-		// Using interpolation on out-of-bounds elements results in hang
-		if ((index_theta <= 0) || (index_theta >= 999))
+		// do a reduction over the total gradient containing prepared "gradient_intra_*" values
+		for ( int off=NUM_OF_THREADS_PER_BLOCK>>1; off>0; off >>= 1)
 		{
-			dependence_on_theta = dependence_on_theta_const[stick_to_bounds(index_theta,0,999)];
-		} else
-		{
-			X0 = angle_const[index_theta];
-			X1 = angle_const[index_theta+1];
-			Y0 = dependence_on_theta_const[index_theta];
-			Y1 = dependence_on_theta_const[index_theta+1];
-			dependence_on_theta = (Y0 * (X1-current_theta) + Y1 * (current_theta-X0)) * inv_angle_delta;
+			barrier(CLK_LOCAL_MEM_FENCE);
+			if (tidx < off)
+			{
+				accumulator_x[tidx] += accumulator_x[tidx+off];
+				accumulator_y[tidx] += accumulator_y[tidx+off];
+				accumulator_z[tidx] += accumulator_z[tidx+off];
+			}
 		}
-		
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-30s %-10.6f\n", "dependence_on_theta: ", dependence_on_theta);
-		#endif
+		if (tidx == 0) {
+			float4 torque_rot;
+			torque_rot.x = accumulator_x[0];
+			torque_rot.y = accumulator_y[0];
+			torque_rot.z = accumulator_z[0];
 
-		// Interpolating rotangle values
-		float dependence_on_rotangle; // Y = dependence_on_rotangle
-		// Using interpolation on previous and/or next elements results in hang
-		// Using interpolation on out-of-bounds elements results in hang
-		if ((index_rotangle <= 0) || (index_rotangle >= 999))
-		{
-			dependence_on_rotangle = dependence_on_rotangle_const[stick_to_bounds(index_rotangle,0,999)];
-		} else
-		{
-			X0 = angle_const[index_rotangle];
-			X1 = angle_const[index_rotangle+1];
-			Y0 = dependence_on_rotangle_const[index_rotangle];
-			Y1 = dependence_on_rotangle_const[index_rotangle+1];
-			dependence_on_rotangle = (Y0 * (X1-current_rotangle) + Y1 * (current_rotangle-X0)) * inv_angle_delta;
-		}
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-20s %-10.6f %-10.6f %-10.6f\n", "final torque: ", torque_rot.x, torque_rot.y, torque_rot.z);
+			#endif
 
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-30s %-10.6f\n", "dependence_on_rotangle: ", dependence_on_rotangle);
-		#endif
+			// Derived from rotation.py/axisangle_to_q()
+			// genes[3:7] = rotation.axisangle_to_q(torque, rad)
+			float torque_length = native_sqrt(torque_rot.x*torque_rot.x+torque_rot.y*torque_rot.y+torque_rot.z*torque_rot.z);
+			torque_length += (torque_length<1e-20f)*1e-20f;
 
-		// Setting gradient rotation-related genotypes in cube
-		// Multiplicating by DEG_TO_RAD is to make it uniform to DEG (see torsion gradients)
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-20s %-10.6f\n", "torque length: ", torque_length);
+			#endif
+
+			// Finding the quaternion that performs
+			// the infinitesimal rotation around torque axis
+			float4 quat_torque = native_divide(torque_rot * SIN_HALF_INFINITESIMAL_RADIAN, torque_length);
+			quat_torque.w = COS_HALF_INFINITESIMAL_RADIAN;
+
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-20s %-10.6f\n", "INFINITESIMAL_RADIAN: ", INFINITESIMAL_RADIAN);
+			printf("%-20s %-10.6f %-10.6f %-10.6f %-10.6f\n", "quat_torque (w,x,y,z): ", quat_torque.w, quat_torque.x, quat_torque.y, quat_torque.z);
+			#endif
+
+			// Converting quaternion gradients into orientation gradients 
+			// Derived from autodockdev/motion.py/_get_cube3_gradient
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-30s %-10.6f %-10.6f %-10.6f %-10.6f\n", "current_q (w,x,y,z): ", genrot_unitvec.w, genrot_unitvec.x, genrot_unitvec.y, genrot_unitvec.z);
+			#endif
+
+			// This is where we want to be in quaternion space
+			// target_q = rotation.q_mult(q, current_q)
+			float4 target_q = quaternion_multiply(quat_torque, genrot_unitvec);
+
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-30s %-10.6f %-10.6f %-10.6f %-10.6f\n", "target_q (w,x,y,z): ", target_q.w, target_q.x, target_q.y, target_q.z);
+			#endif
+
+			// This is where we are in the orientation axis-angle space
+			// Equivalent to "current_oclacube" in autodockdev/motions.py
+			float current_phi      = fmod_pi2(PI_TIMES_2 + phi);
+			float current_theta    = fmod_pi2(PI_TIMES_2 + theta);
+			float current_rotangle = fmod_pi2(PI_TIMES_2 + genrotangle);
+
+			// This is where we want to be in the orientation axis-angle space
+			float target_phi, target_theta, target_rotangle;
+
+			// target_oclacube = quaternion_to_oclacube(target_q, theta_larger_than_pi)
+			// Derived from autodockdev/motions.py/quaternion_to_oclacube()
+			// In our terms means quaternion_to_oclacube(target_q{w|x|y|z}, theta_larger_than_pi)
+			target_rotangle = 2.0f * fast_acos(target_q.w); // = 2.0f * ang;
+			float inv_sin_ang = native_rsqrt(1.0f-target_q.w*target_q.w); // = 1.0/native_sin(ang);
+
+			target_theta = PI_TIMES_2 + is_theta_gt_pi * fast_acos( target_q.z * inv_sin_ang );
+			target_phi   = fmod_pi2((atan2( is_theta_gt_pi*target_q.y, is_theta_gt_pi*target_q.x) + PI_TIMES_2));
+
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-30s %-10.6f %-10.6f %-10.6f\n", "target_axisangle (1,2,3): ", target_phi, target_theta, target_rotangle);
+			#endif
+
+			// The infinitesimal rotation will produce an infinitesimal displacement
+			// in shoemake space. This is to guarantee that the direction of
+			// the displacement in shoemake space is not distorted.
+			// The correct amount of displacement in shoemake space is obtained
+			// by multiplying the infinitesimal displacement by shoemake_scaling:
+			float orientation_scaling = torque_length * INV_INFINITESIMAL_RADIAN;
+
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-30s %-10.6f\n", "orientation_scaling: ", orientation_scaling);
+			#endif
+
+			// Derivates in cube3
+			float grad_phi, grad_theta, grad_rotangle;
+			grad_phi      = orientation_scaling * (fmod_pi2(target_phi      - current_phi      + PI_FLOAT) - PI_FLOAT);
+			grad_theta    = orientation_scaling * (fmod_pi2(target_theta    - current_theta    + PI_FLOAT) - PI_FLOAT);
+			grad_rotangle = orientation_scaling * (fmod_pi2(target_rotangle - current_rotangle + PI_FLOAT) - PI_FLOAT);
+
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-30s \n", "grad_axisangle (1,2,3) - before empirical scaling: ");
+			printf("%-13s %-13s %-13s \n", "grad_phi", "grad_theta", "grad_rotangle");
+			printf("%-13.6f %-13.6f %-13.6f\n", grad_phi, grad_theta, grad_rotangle);
+			#endif
+
+			// Correcting theta gradients interpolating 
+			// values from correction look-up-tables
+			// (X0,Y0) and (X1,Y1) are known points
+			// How to find the Y value in the straight line between Y0 and Y1,
+			// corresponding to a certain X?
+			/*
+				| dependence_on_theta_const
+				| dependence_on_rotangle_const
+				|
+				|
+				|                        Y1
+				|
+				|             Y=?
+				|    Y0
+				|_________________________________ angle_const
+				     X0         X        X1
+			*/
+
+			// Finding the index-position of "grad_delta" in the "angle_const" array
+			//uint index_theta    = floor(native_divide(current_theta    - angle_const[0], angle_delta));
+			//uint index_rotangle = floor(native_divide(current_rotangle - angle_const[0], angle_delta));
+			uint index_theta    = floor((current_theta    - angle_const[0]) * inv_angle_delta);
+			uint index_rotangle = floor((current_rotangle - angle_const[0]) * inv_angle_delta);
+
+			// Interpolating theta values
+			// X0 -> index - 1
+			// X1 -> index + 1
+			// Expressed as weighted average:
+			// Y = [Y0 * ((X1 - X) / (X1-X0))] +  [Y1 * ((X - X0) / (X1-X0))]
+			// Simplified for GPU (less terms):
+			// Y = [Y0 * (X1 - X) + Y1 * (X - X0)] / (X1 - X0)
+			// Taking advantage of constant:
+			// Y = [Y0 * (X1 - X) + Y1 * (X - X0)] * inv_angle_delta
+
+			float X0, Y0;
+			float X1, Y1;
+			float dependence_on_theta; //Y = dependence_on_theta
+
+			// Using interpolation on out-of-bounds elements results in hang
+			if ((index_theta <= 0) || (index_theta >= 999))
+			{
+				dependence_on_theta = dependence_on_theta_const[stick_to_bounds(index_theta,0,999)];
+			} else
+			{
+				X0 = angle_const[index_theta];
+				X1 = angle_const[index_theta+1];
+				Y0 = dependence_on_theta_const[index_theta];
+				Y1 = dependence_on_theta_const[index_theta+1];
+				dependence_on_theta = (Y0 * (X1-current_theta) + Y1 * (current_theta-X0)) * inv_angle_delta;
+			}
+
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-30s %-10.6f\n", "dependence_on_theta: ", dependence_on_theta);
+			#endif
+
+			// Interpolating rotangle values
+			float dependence_on_rotangle; // Y = dependence_on_rotangle
+			// Using interpolation on previous and/or next elements results in hang
+			// Using interpolation on out-of-bounds elements results in hang
+			if ((index_rotangle <= 0) || (index_rotangle >= 999))
+			{
+				dependence_on_rotangle = dependence_on_rotangle_const[stick_to_bounds(index_rotangle,0,999)];
+			} else
+			{
+				X0 = angle_const[index_rotangle];
+				X1 = angle_const[index_rotangle+1];
+				Y0 = dependence_on_rotangle_const[index_rotangle];
+				Y1 = dependence_on_rotangle_const[index_rotangle+1];
+				dependence_on_rotangle = (Y0 * (X1-current_rotangle) + Y1 * (current_rotangle-X0)) * inv_angle_delta;
+			}
+
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-30s %-10.6f\n", "dependence_on_rotangle: ", dependence_on_rotangle);
+			#endif
+
+			// Setting gradient rotation-related genotypes in cube
+			// Multiplicating by DEG_TO_RAD is to make it uniform to DEG (see torsion gradients)
 #ifdef FLOAT_GRADIENTS
-		gradient_genotype[3] = native_divide(grad_phi, (dependence_on_theta * dependence_on_rotangle)) * DEG_TO_RAD;
-		gradient_genotype[4] = native_divide(grad_theta, dependence_on_rotangle) * DEG_TO_RAD;
-		gradient_genotype[5] = grad_rotangle * DEG_TO_RAD;
+			gradient_genotype[3] = native_divide(grad_phi, (dependence_on_theta * dependence_on_rotangle)) * DEG_TO_RAD;
+			gradient_genotype[4] = native_divide(grad_theta, dependence_on_rotangle) * DEG_TO_RAD;
+			gradient_genotype[5] = grad_rotangle * DEG_TO_RAD;
 #else
-		i_gradient_genotype[3] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * native_divide(grad_phi, (dependence_on_theta * dependence_on_rotangle)) * DEG_TO_RAD)));
-		i_gradient_genotype[4] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * native_divide(grad_theta, dependence_on_rotangle) * DEG_TO_RAD)));
-		i_gradient_genotype[5] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * grad_rotangle * DEG_TO_RAD)));
+			i_gradient_genotype[3] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * native_divide(grad_phi, (dependence_on_theta * dependence_on_rotangle)) * DEG_TO_RAD)));
+			i_gradient_genotype[4] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * native_divide(grad_theta, dependence_on_rotangle) * DEG_TO_RAD)));
+			i_gradient_genotype[5] = float2int_round(fmin(MAXTERM, fmax(-MAXTERM, TERMSCALE * grad_rotangle * DEG_TO_RAD)));
 #endif
-		#if defined (PRINT_GRAD_ROTATION_GENES)
-		printf("\n%s\n", "----------------------------------------------------------");
-		printf("%-30s \n", "grad_axisangle (1,2,3) - after empirical scaling: ");
-		printf("%-13s %-13s %-13s \n", "grad_phi", "grad_theta", "grad_rotangle");
-		printf("%-13.6f %-13.6f %-13.6f\n", gradient_genotype[3], gradient_genotype[4], gradient_genotype[5]);
-		#endif
+			#if defined (PRINT_GRAD_ROTATION_GENES)
+			printf("\n%s\n", "----------------------------------------------------------");
+			printf("%-30s \n", "grad_axisangle (1,2,3) - after empirical scaling: ");
+			printf("%-13s %-13s %-13s \n", "grad_phi", "grad_theta", "grad_rotangle");
+			printf("%-13.6f %-13.6f %-13.6f\n", gradient_genotype[3], gradient_genotype[4], gradient_genotype[5]);
+			#endif
+		}
 	}
 
 	// ------------------------------------------

--- a/device/calcenergy.cl
+++ b/device/calcenergy.cl
@@ -201,22 +201,24 @@ void gpu_calc_energy(
 
 	// General rotation moving vector
 	float4 genrot_movingvec;
-	genrot_movingvec.x = genotype[0];
-	genrot_movingvec.y = genotype[1];
-	genrot_movingvec.z = genotype[2];
-	genrot_movingvec.w = 0.0f;
 	// Convert orientation genes from sex. to radians
 	float phi         = genotype[3] * DEG_TO_RAD;
 	float theta       = genotype[4] * DEG_TO_RAD;
 	float genrotangle = genotype[5] * DEG_TO_RAD;
 
 	float4 genrot_unitvec;
-	float sin_angle = native_sin(theta);
-	float s2 = native_sin(genrotangle*0.5f);
-	genrot_unitvec.x = s2*sin_angle*native_cos(phi);
-	genrot_unitvec.y = s2*sin_angle*native_sin(phi);
-	genrot_unitvec.z = s2*native_cos(theta);
-	genrot_unitvec.w = native_cos(genrotangle*0.5f);
+	if(dockpars_true_ligand_atoms){
+		genrot_movingvec.x = genotype[0];
+		genrot_movingvec.y = genotype[1];
+		genrot_movingvec.z = genotype[2];
+		genrot_movingvec.w = 0.0f;
+		float sin_angle = native_sin(theta);
+		float s2 = native_sin(genrotangle*0.5f);
+		genrot_unitvec.x = s2*sin_angle*native_cos(phi);
+		genrot_unitvec.y = s2*sin_angle*native_sin(phi);
+		genrot_unitvec.z = s2*native_cos(theta);
+		genrot_unitvec.w = native_cos(genrotangle*0.5f);
+	}
 
 	uint g1 = dockpars_gridsize_x;
 	uint g2 = dockpars_gridsize_x_times_y;

--- a/device/kernel3.cl
+++ b/device/kernel3.cl
@@ -90,6 +90,7 @@ __constant       kernelconstant_conform*      kerconst_conform
 	__local float candidate_energy;
 	__local int   evaluation_cnt;
 	int gene_counter;
+	int gene_start = (dockpars_true_ligand_atoms==0)*6;
 
 	__local float offspring_genotype[ACTUAL_GENOTYPE_LENGTH];
 	__local int run_id;
@@ -158,7 +159,7 @@ __constant       kernelconstant_conform*      kerconst_conform
 	while ((iteration_cnt < dockpars_max_num_of_iters) && (rho > dockpars_rho_lower_bound))
 	{
 		// New random deviate
-		for (gene_counter = tidx;
+		for (gene_counter = tidx+gene_start;
 		     gene_counter < dockpars_num_of_genes;
 		     gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -192,7 +193,7 @@ __constant       kernelconstant_conform*      kerconst_conform
 		}
 
 		// Generating new genotype candidate
-		for (gene_counter = tidx;
+		for (gene_counter = tidx+gene_start;
 		     gene_counter < dockpars_num_of_genes;
 		     gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 		{
@@ -259,7 +260,7 @@ __constant       kernelconstant_conform*      kerconst_conform
 
 		if (candidate_energy < offspring_energy) // If candidate is better, success
 		{
-			for (gene_counter = tidx;
+			for (gene_counter = tidx+gene_start;
 			     gene_counter < dockpars_num_of_genes;
 			     gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 			{
@@ -284,7 +285,7 @@ __constant       kernelconstant_conform*      kerconst_conform
 		else // If candidate is worse, check the opposite direction
 		{
 			// Generating the other genotype candidate
-			for (gene_counter = tidx;
+			for (gene_counter = tidx+gene_start;
 			     gene_counter < dockpars_num_of_genes;
 			     gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 			{
@@ -352,7 +353,7 @@ __constant       kernelconstant_conform*      kerconst_conform
 
 			if (candidate_energy < offspring_energy) // If candidate is better, success
 			{
-				for (gene_counter = tidx;
+				for (gene_counter = tidx+gene_start;
 				     gene_counter < dockpars_num_of_genes;
 				     gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 				{
@@ -376,7 +377,7 @@ __constant       kernelconstant_conform*      kerconst_conform
 			}
 			else // Failure in both directions
 			{
-				for (gene_counter = tidx;
+				for (gene_counter = tidx+gene_start;
 				     gene_counter < dockpars_num_of_genes;
 				     gene_counter+= NUM_OF_THREADS_PER_BLOCK)
 					// Updating genotype_bias

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -119,6 +119,7 @@ typedef struct _Dockpars
 	char*                     xrayligandfile                  = NULL;  // by default will be ligand file name
 	char*                     resname                         = NULL; // by default will be ligand file basename
 	bool                      given_xrayligandfile            = false; // That is, not given (explicitly by the user)
+	bool                      free_roaming_ligand             = true;
 	bool                      autostop                        = true;
 	unsigned int              as_frequency                    = 5;
 	float                     stopstd                         = 0.15;

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -119,7 +119,7 @@ typedef struct _Dockpars
 	char*                     xrayligandfile                  = NULL;  // by default will be ligand file name
 	char*                     resname                         = NULL; // by default will be ligand file basename
 	bool                      given_xrayligandfile            = false; // That is, not given (explicitly by the user)
-	bool                      free_roaming_ligand             = true;
+	bool                      free_roaming_ligand             = false;
 	bool                      autostop                        = true;
 	unsigned int              as_frequency                    = 5;
 	float                     stopstd                         = 0.15;

--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -56,6 +56,8 @@ typedef struct _Liganddata
 	int            num_of_rotbonds;
 // true_ligand_rotbonds:  Number of rotatable bonds in the ligand only.
 	int            true_ligand_rotbonds;
+// ligand id: which ligand does a given atom belong to
+	int            ligand_id             [MAX_NUM_OF_ATOMS];
 // atom_names:            Each row (first index) contain the ligand atom name
 	char           atom_names            [MAX_NUM_OF_ATOMS][5];
 // atom_types:            Each row (first index) contain an atom type (as two characters),

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -942,7 +942,6 @@ int get_filelist(
 				last_fld_idx = filelist.fld_files.size();
 				prev_line_was_fld=false;
 				lone_flex_or_covalent=false;
-				mypars->free_roaming_ligand=true;
 			}
 			if (len>=4 && line.compare(len-4,4,".fld") == 0){
 				bool new_grid=true;
@@ -989,6 +988,7 @@ int get_filelist(
 			} else if (len>=6 && line.compare(len-6,6,".pdbqt") == 0){
 				// Add the .pdbqt
 				filelist.ligand_files.push_back(line);
+				mypars->free_roaming_ligand=true;
 				// Add entry to filelist
 				if((ret=filelist_add(mypars,mygrid,filelist))) return ret;
 				// Keep track of fld lines actually used

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -1000,6 +1000,14 @@ int get_filelist(
 				filelist.resnames.push_back(line);
 			}
 		}
+		// take care of potential last flex/covalent entry
+		if(lone_flex_or_covalent){
+			// Add the .pdbqt
+			filelist.ligand_files.push_back(mypars->flexresfile);
+			mypars->free_roaming_ligand=false;
+			// Add entry to filelist
+			if((ret=filelist_add(mypars,mygrid,filelist))) return ret;
+		}
 
 		filelist.nfiles = filelist.ligand_files.size();
 		if(filelist.nfiles>0) filelist.used = true;

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -889,6 +889,7 @@ int get_filelist(
 			if(len<1) len=strlen(ligands[i]);
 			filelist.resnames.push_back(filelist.ligand_files[i].substr(0,len));
 			mypars->resname=strdup(filelist.resnames[i].c_str());
+			mypars->free_roaming_ligand=true;
 			// Add the parameter block
 			filelist.mypars.push_back(*mypars);
 		}

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -1079,6 +1079,7 @@ int get_filenames_and_ADcoeffs(
 			{
 				lfile_given = 1;
 				mypars->ligandfile = strdup(argv[i+1]);
+				mypars->free_roaming_ligand = true;
 			}
 		}
 

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -183,7 +183,8 @@ int parse_dpf(
 						if(!mypars->xml2dlg){
 							sscanf(line.c_str(),"%*s %255s",argstr);
 							if(mypars->ligandfile) free(mypars->ligandfile);
-							mypars->ligandfile = strdup(argstr);
+							if(strincmp(argstr,"empty",5) != 0)
+								mypars->ligandfile = strdup(argstr);
 						}
 						break;
 				case DPF_FLEXRES: // flexibe residue file name
@@ -373,7 +374,7 @@ int parse_dpf(
 									filelist.preload_maps=false;
 								}
 								// Add the ligand to filelist
-								if(mypars->ligandfile != NULL){ // no free ligand file specified (test for covalent below)
+								if(mypars->ligandfile != NULL){ // free ligand file specified (test for covalent below)
 									filelist.ligand_files.push_back(mypars->ligandfile);
 									mypars->free_roaming_ligand = true;
 								} else{

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -341,7 +341,8 @@ int main(int argc, char* argv[])
 					if (filelist.used){
 						printf(":\n");
 						printf("(   Grid map file: %s )\n",  mypars.fldfile);
-						printf("(   Ligand file: %s )\n", mypars.ligandfile); fflush(stdout);
+						if(mypars.ligandfile)
+							printf("(   Ligand file: %s )\n", mypars.ligandfile); fflush(stdout);
 						if(mypars.flexresfile)
 							printf("(   Flexible residue: %s )\n", mypars.flexresfile);
 						fflush(stdout);
@@ -405,7 +406,8 @@ int main(int argc, char* argv[])
 					para_printf(":\n");
 					para_printf("    Device: %s\n", tData[dev_nr].device_name);
 					para_printf("    Grid map file: %s\n",  mypars.fldfile);
-					para_printf("    Ligand file: %s\n", mypars.ligandfile); fflush(stdout);
+					if(mypars.ligandfile)
+						para_printf("    Ligand file: %s\n", mypars.ligandfile); fflush(stdout);
 					if(mypars.flexresfile)
 						para_printf("    Flexible residue: %s\n", mypars.flexresfile);
 					fflush(stdout);

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -62,16 +62,24 @@ int init_liganddata(
 	char tempstr [256];
 	std::string line;
 
+	unsigned int ls=0;
+	if ( ligfilename==NULL ) {
+		ls++;
+	}
 	unsigned int lnr=1;
-	if ( flexresfilename!=NULL) {
+	if ( flexresfilename!=NULL ) {
 		if ( strlen(flexresfilename)>0 )
 			lnr++;
+	}
+	if ( lnr-ls <= 0){
+		printf("Error: No ligand or flex res file specified.\n");
+		return 1;
 	}
 
 	num_of_atypes = 0;
 	num_of_base_atypes = 0;
 	unsigned int atom_cnt = 0;
-	for (unsigned int l=0; l<lnr; l++)
+	for (unsigned int l=ls; l<lnr; l++)
 	{
 		if(l==0)
 			fp.open(ligfilename);

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -2029,7 +2029,7 @@ float calc_interE_f(
 			peratom_vdw[atom_cnt] = v;
 #endif
 			peratom_elec[atom_cnt] = e;
-			*elecE += e;
+			if (atom_cnt < myligand->true_ligand_atoms) *elecE += e; // only want intermolecular contributions
 		}
 
 		if (debug == 1)

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -634,6 +634,9 @@ int get_bonds(Liganddata* myligand)
 		is_HD1=(strcmp(myligand->base_atom_types[atom_typeid1],"HD")==0);
 		for (atom_id2=atom_id1+1; atom_id2 < myligand->num_of_atoms; atom_id2++)
 		{
+			if(myligand->ligand_id[atom_id1]!=myligand->ligand_id[atom_id2]){
+				continue; // skip pairs that are on different ligands
+			}
 			atom_typeid2 = myligand->atom_idxyzq[atom_id2][0];
 			is_HD2=(strcmp(myligand->base_atom_types[atom_typeid2],"HD")==0);
 			temp_point1[0] = myligand->atom_idxyzq[atom_id1][1];
@@ -1148,6 +1151,7 @@ int parse_liganddata(
 	int branch_start;
 	int endbranch_counter = 0;
 	int branches [MAX_NUM_OF_ROTBONDS][3];
+	int ligand_count = 0;
 	int i,j,k;
 	unsigned int atom_rotbonds_temp [MAX_NUM_OF_ATOMS][MAX_NUM_OF_ROTBONDS];
 	memset(atom_rotbonds_temp,0,MAX_NUM_OF_ATOMS*MAX_NUM_OF_ROTBONDS*sizeof(unsigned int));
@@ -1222,6 +1226,7 @@ int parse_liganddata(
 			line_count++;
 			sscanf(line.c_str(),"%255s",tempstr);
 			if ((l>0) && (strcmp(tempstr, "ROOT") == 0)){
+				ligand_count++;
 				flex_root = atom_counter;
 				atom_rot_start = atom_counter;
 				branch_start = branch_counter;
@@ -1239,6 +1244,7 @@ int parse_liganddata(
 						/* else it is 2, so it is closed, so nothing to be done... */
 
 				myligand->atom_rigid_structures [atom_counter] = current_rigid_struct_id; // using the id of the current rigid structure
+				myligand->ligand_id [atom_counter ] = ligand_count;
 
 				if (l>0)
 					if (atom_counter-flex_root<2)

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -2163,8 +2163,7 @@ float calc_intraE_f(
 				// FIXME: accumulated into vW ... is that correct?
 				if (((atom1_type_vdw_hb == ATYPE_CG_IDX) && (atom2_type_vdw_hb == ATYPE_G0_IDX)) ||
 				    ((atom1_type_vdw_hb == ATYPE_G0_IDX) && (atom2_type_vdw_hb == ATYPE_CG_IDX))) {
-					if (((atom_id1<myligand->true_ligand_atoms) && (atom_id2<myligand->true_ligand_atoms)) ||
-					    ((atom_id1>=myligand->true_ligand_atoms) && (atom_id2>=myligand->true_ligand_atoms))) // if both atoms are of either a ligand or a flex res it's intra
+					if ((a_flex + b_flex) & 1) // if both atoms are of either a ligand or a flex res it's intra
 						vW += G * dist;
 					else
 						interflexE += G * dist;

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -1194,7 +1194,7 @@ int parse_liganddata(
 				if (set_liganddata_typeid(myligand, mygrid, atom_counter, tempstr) != 0) // the function sets the type index
 					return 1;
 				if(tempstr[0]=='G'){ // G-type are ignored for inter calc unless there is a map specified (checked above)
-					if(myligand->atom_idxyzq[atom_counter][0]==myligand->base_type_idx[(int)myligand->atom_idxyzq[atom_counter][0]])
+					if(strcmp(myligand->atom_types[(int)myligand->atom_idxyzq[atom_counter][0]],myligand->base_atom_types[(int)myligand->atom_idxyzq[atom_counter][0]])==0) // derived Gx type does not exists
 						myligand->ignore_inter[atom_counter] = true;
 				}
 				atom_counter++;

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -893,12 +893,17 @@ void generate_output(
 			fprintf(fp, "DOCKED: USER\n");
 			if(mypars->xml2dlg || mypars->contact_analysis){
 				fprintf(fp, "DOCKED: USER    NEWDPF about 0.0 0.0 0.0\n");
-				fprintf(fp, "DOCKED: USER    NEWDPF tran0 %.6f %.6f %.6f\n", myresults[i].genotype[0]*mygrid->spacing, myresults[i].genotype[1]*mygrid->spacing, myresults[i].genotype[2]*mygrid->spacing);
-				if(!mypars->xml2dlg){
-					double phi = myresults[i].genotype[3]/180.0*PI;
-					double theta = myresults[i].genotype[4]/180.0*PI;
-					fprintf(fp, "DOCKED: USER    NEWDPF axisangle0 %.8f %.8f %.8f %.6f\n", sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta), myresults[i].genotype[5]);
-				} else fprintf(fp, "DOCKED: USER    NEWDPF axisangle0 %.8f %.8f %.8f %.6f\n", myresults[i].genotype[3], myresults[i].genotype[4], myresults[i].genotype[5], myresults[i].genotype[GENOTYPE_LENGTH_IN_GLOBMEM-1]);
+				if(mypars->free_roaming_ligand){
+					fprintf(fp, "DOCKED: USER    NEWDPF tran0 %.6f %.6f %.6f\n", myresults[i].genotype[0]*mygrid->spacing, myresults[i].genotype[1]*mygrid->spacing, myresults[i].genotype[2]*mygrid->spacing);
+					if(!mypars->xml2dlg){
+						double phi = myresults[i].genotype[3]/180.0*PI;
+						double theta = myresults[i].genotype[4]/180.0*PI;
+						fprintf(fp, "DOCKED: USER    NEWDPF axisangle0 %.8f %.8f %.8f %.6f\n", sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta), myresults[i].genotype[5]);
+					} else fprintf(fp, "DOCKED: USER    NEWDPF axisangle0 %.8f %.8f %.8f %.6f\n", myresults[i].genotype[3], myresults[i].genotype[4], myresults[i].genotype[5], myresults[i].genotype[GENOTYPE_LENGTH_IN_GLOBMEM-1]);
+				} else{
+					fprintf(fp, "DOCKED: USER    NEWDPF tran0 0.0 0.0 0.0\n");
+					fprintf(fp, "DOCKED: USER    NEWDPF axisangle0 1.0 0.0 0.0 0.0\n");
+				}
 				fprintf(fp, "DOCKED: USER    NEWDPF dihe0");
 				for(j=0; j<ligand_ref->num_of_rotbonds; j++)
 					fprintf(fp, " %.6f", myresults[i].genotype[6+j]);
@@ -1204,10 +1209,15 @@ void generate_output(
 			fprintf(fp_xml, "\t\t\t<final_intermol_NRG> %.2f</final_intermol_NRG>\n", myresults[j].interE + myresults[j].interflexE);
 			fprintf(fp_xml, "\t\t\t<internal_ligand_NRG>%.2f</internal_ligand_NRG>\n", myresults[j].intraE + myresults[j].intraflexE);
 			fprintf(fp_xml, "\t\t\t<torsonial_free_NRG> %.2f</torsonial_free_NRG>\n", torsional_energy);
-			fprintf(fp_xml, "\t\t\t<tran0>%.6f %.6f %.6f</tran0>\n", myresults[j].genotype[0]*mygrid->spacing, myresults[j].genotype[1]*mygrid->spacing, myresults[j].genotype[2]*mygrid->spacing);
-			phi = myresults[j].genotype[3]/180.0*PI;
-			theta = myresults[j].genotype[4]/180.0*PI;
-			fprintf(fp_xml, "\t\t\t<axisangle0>%.8f %.8f %.8f %.6f</axisangle0>\n", sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta), myresults[j].genotype[5]);
+			if(mypars->free_roaming_ligand){
+				fprintf(fp_xml, "\t\t\t<tran0>%.6f %.6f %.6f</tran0>\n", myresults[j].genotype[0]*mygrid->spacing, myresults[j].genotype[1]*mygrid->spacing, myresults[j].genotype[2]*mygrid->spacing);
+				phi = myresults[j].genotype[3]/180.0*PI;
+				theta = myresults[j].genotype[4]/180.0*PI;
+				fprintf(fp_xml, "\t\t\t<axisangle0>%.8f %.8f %.8f %.6f</axisangle0>\n", sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta), myresults[j].genotype[5]);
+			} else{
+				fprintf(fp_xml, "\t\t\t<tran0>0.0 0.0 0.0</tran0>\n");
+				fprintf(fp_xml, "\t\t\t<axisangle0>1.0 0.0 0.0 0.0</axisangle0>\n");
+			}
 			fprintf(fp_xml, "\t\t\t<ndihe>%d</ndihe>\n", ligand_ref->num_of_rotbonds);
 			fprintf(fp_xml, "\t\t\t<dihe0>");
 			for(i=0; i<ligand_ref->num_of_rotbonds; i++)

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -1210,7 +1210,7 @@ void generate_output(
 					}
 					fprintf(fp_xml, "\t\t\t\t<contact_analysis_types>  %s</contact_analysis_types>\n", types.c_str());
 					fprintf(fp_xml, "\t\t\t\t<contact_analysis_ligid>  %s</contact_analysis_ligid>\n", lig_id.c_str());
-					fprintf(fp_xml, "\t\t\t\t<contact_analysis_ligname>%s</contact_analsyis_ligname>\n", ligname.c_str());
+					fprintf(fp_xml, "\t\t\t\t<contact_analysis_ligname>%s</contact_analysis_ligname>\n", ligname.c_str());
 					fprintf(fp_xml, "\t\t\t\t<contact_analysis_recid>  %s</contact_analysis_recid>\n", rec_id.c_str());
 					fprintf(fp_xml, "\t\t\t\t<contact_analysis_recname>%s</contact_analysis_recname>\n", rec_name.c_str());
 					fprintf(fp_xml, "\t\t\t\t<contact_analysis_residue>%s</contact_analysis_residue>\n", residue.c_str());

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -295,10 +295,12 @@ void write_basic_info_dlg(
 		fprintf(fp, "    LIGAND PARAMETERS\n");
 	fprintf(fp, "    ________________________\n\n\n");
 
-	fprintf(fp, "Ligand name:                               ");
-	int len = strlen(mypars->ligandfile) - 6;
-	for(i=0; i<len; i++) fputc(mypars->ligandfile[i], fp);
-	fputc('\n', fp);
+	if(mypars->ligandfile){
+		fprintf(fp, "Ligand name:                               ");
+		int len = strlen(mypars->ligandfile) - 6;
+		for(i=0; i<len; i++) fputc(mypars->ligandfile[i], fp);
+		fputc('\n', fp);
+	}
 	if(flexres){
 		fprintf(fp, "Flexres name:                              ");
 		int len = strlen(mypars->flexresfile) - 6;
@@ -320,7 +322,7 @@ void write_basic_info_dlg(
 		fprintf(fp, "DPF> outlev 1\n");
 		fprintf(fp, "DPF> ga_run %lu\n", mypars->num_of_runs);
 		fprintf(fp, "DPF> fld %s\n", mygrid->fld_name.c_str());
-		fprintf(fp, "DPF> move %s\n", mypars->ligandfile);
+		if(mypars->ligandfile) fprintf(fp, "DPF> move %s\n", mypars->ligandfile);
 		if(flexres) fprintf(fp, "DPF> flexres %s\n", mypars->flexresfile);
 		fprintf(fp, "\n\n");
 	}
@@ -358,7 +360,9 @@ void make_resfiles(
 	double entity_rmsds;
 	double init_atom_idxyzq[MAX_NUM_OF_ATOMS][5]; // type id .. 0, x .. 1, y .. 2, z .. 3, q ... 4
 	memcpy(init_atom_idxyzq, ligand_ref->atom_idxyzq, sizeof(ligand_ref->atom_idxyzq));
-	int len = strlen(mypars->ligandfile) - 6 + 24 + 10 + 10; // length with added bits for things below (numbers below 11 digits should be a safe enough threshold)
+	char* basefile = mypars->ligandfile;
+	if(!mypars->free_roaming_ligand) basefile = mypars->flexresfile;
+	int len = strlen(basefile) - 6 + 24 + 10 + 10; // length with added bits for things below (numbers below 11 digits should be a safe enough threshold)
 	char* temp_filename = (char*)malloc((len+1)*sizeof(char)); // +\0 at the end
 	char* name_ext_start;
 	float accurate_interE;
@@ -401,8 +405,8 @@ void make_resfiles(
 
 	// Writing out state of final population
 
-	strcpy(temp_filename, mypars->ligandfile);
-	name_ext_start = temp_filename + strlen(mypars->ligandfile) - 6; // without .pdbqt
+	strcpy(temp_filename, basefile);
+	name_ext_start = temp_filename + strlen(basefile) - 6; // without .pdbqt
 
 	bool rmsd_valid = true;
 	if (mypars->given_xrayligandfile == true) {
@@ -493,13 +497,13 @@ void make_resfiles(
 				best_energy_of_all = accurate_interE + accurate_intraE;
 
 				if (mypars->gen_best)
-					gen_new_pdbfile(mypars->ligandfile, "best.pdbqt", ligand_ref);
+					gen_new_pdbfile(basefile, "best.pdbqt", ligand_ref);
 			}
 
 		if (i < mypars->gen_pdbs) //if it is necessary, making new pdbqts for best entities
 		{
 			sprintf(name_ext_start, "_docked_run%d_entity%d.pdbqt", run_cnt+1, i+1); //name will be <original pdb filename>_docked_<number starting from 1>.pdb
-			gen_new_pdbfile(mypars->ligandfile, temp_filename, ligand_ref);
+			gen_new_pdbfile(basefile, temp_filename, ligand_ref);
 		}
 		if (mypars->gen_finalpop)
 		{
@@ -1122,7 +1126,8 @@ void generate_output(
 		if(mypars->list_nr>1)
 			fprintf(fp_xml, "\t<list_nr>%u</list_nr>\n",mypars->list_nr);
 		fprintf(fp_xml, "\t<grid>%s</grid>\n", mypars->fldfile);
-		fprintf(fp_xml, "\t<ligand>%s</ligand>\n", mypars->ligandfile);
+		if(mypars->ligandfile)
+			fprintf(fp_xml, "\t<ligand>%s</ligand>\n", mypars->ligandfile);
 		if(mypars->flexresfile)
 			fprintf(fp_xml, "\t<flexres>%s</flexres>\n",mypars->flexresfile);
 		fprintf(fp_xml, "\t<seed>");

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -79,7 +79,8 @@ void write_basic_info(
 	fprintf(fp, "         DOCKING PARAMETERS        \n");
 	fprintf(fp, "===================================\n\n");
 
-	fprintf(fp, "Ligand file:                               %s\n", mypars->ligandfile);
+	if(mypars->ligandfile)
+		fprintf(fp, "Ligand file:                               %s\n", mypars->ligandfile);
 	bool flexres = false;
 	if (mypars->flexresfile!=NULL){
 			if ( strlen(mypars->flexresfile)>0 ) {
@@ -211,7 +212,8 @@ void write_basic_info_dlg(
 	fprintf(fp, "    DOCKING PARAMETERS\n");
 	fprintf(fp, "    ________________________\n\n\n");
 
-	fprintf(fp, "Ligand file:                               %s\n", mypars->ligandfile);
+	if(mypars->ligandfile)
+		fprintf(fp, "Ligand file:                               %s\n", mypars->ligandfile);
 	bool flexres = false;
 	if (mypars->flexresfile!=NULL){
 			if ( strlen(mypars->flexresfile)>0 ) {
@@ -730,34 +732,35 @@ void generate_output(
 			fprintf(fp, "\n\n");
 		}
 		// writing input pdbqt file
-		fprintf(fp, "    INPUT LIGAND PDBQT FILE:\n    ________________________\n\n\n");
-		ligand_calc_output(fp, "INPUT-LIGAND-PDBQT: USER", tables, ligand_ref, mypars, mygrid, mypars->contact_analysis, output_ref_calcs);
 		unsigned int line_count = 0;
-		while (line_count < ligand_ref->ligand_line_count)
-		{
-			strcpy(tempstr,ligand_ref->file_content[line_count].c_str());
-			line_count++;
-			fprintf(fp, "INPUT-LIGAND-PDBQT: %s", tempstr);
-			if ((strncmp("ATOM", tempstr, 4) == 0) || (strncmp("HETATM", tempstr, 6) == 0))
+		if(mypars->free_roaming_ligand){
+			fprintf(fp, "    INPUT LIGAND PDBQT FILE:\n    ________________________\n\n\n");
+			ligand_calc_output(fp, "INPUT-LIGAND-PDBQT: USER", tables, ligand_ref, mypars, mygrid, mypars->contact_analysis, output_ref_calcs);
+			while (line_count < ligand_ref->ligand_line_count)
 			{
-				tempstr[30] = '\0';
-				sprintf(lineout, "DOCKED: %s", tempstr);
-				pdbqt_template += lineout;
-				atom_data.push_back(pdbqt_template.length());
-			} else{
-				if (strncmp("ROOT", tempstr, 4) == 0)
+				strcpy(tempstr,ligand_ref->file_content[line_count].c_str());
+				line_count++;
+				fprintf(fp, "INPUT-LIGAND-PDBQT: %s", tempstr);
+				if ((strncmp("ATOM", tempstr, 4) == 0) || (strncmp("HETATM", tempstr, 6) == 0))
 				{
-					pdbqt_template += "DOCKED: USER                              x       y       z     vdW  Elec       q    Type\n";
-					pdbqt_template += "DOCKED: USER                           _______ _______ _______ _____ _____    ______ ____\n";
+					tempstr[30] = '\0';
+					sprintf(lineout, "DOCKED: %s", tempstr);
+					pdbqt_template += lineout;
+					atom_data.push_back(pdbqt_template.length());
+				} else{
+					if (strncmp("ROOT", tempstr, 4) == 0)
+					{
+						pdbqt_template += "DOCKED: USER                              x       y       z     vdW  Elec       q    Type\n";
+						pdbqt_template += "DOCKED: USER                           _______ _______ _______ _____ _____    ______ ____\n";
+					}
+					sprintf(lineout, "DOCKED: %s", tempstr);
+					pdbqt_template += lineout;
 				}
-				sprintf(lineout, "DOCKED: %s", tempstr);
-				pdbqt_template += lineout;
 			}
+			fprintf(fp, "\n\n");
 		}
-		fprintf(fp, "\n\n");
-		
 		// writing input flexres pdbqt file if specified
-		if (mypars->flexresfile!=NULL) {
+		if (mypars->flexresfile) {
 			if ( strlen(mypars->flexresfile)>0 ) {
 				fprintf(fp, "    INPUT FLEXRES PDBQT FILE:\n    ________________________\n\n\n");
 				while (line_count < ligand_ref->file_content.size())

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -285,7 +285,7 @@ int setup(
 	}
 
 	// Filling the atom types field of myligand according to the grid types
-	if (init_liganddata(mypars->ligandfile,
+	if (init_liganddata(mypars->free_roaming_ligand ? mypars->ligandfile : NULL,
 	                    mypars->flexresfile,
 	                    &myligand_init,
 	                    mygrid,

--- a/wrapcl/src/Kernels.cpp
+++ b/wrapcl/src/Kernels.cpp
@@ -365,10 +365,8 @@ int runKernel1D(
 	cl_ulong stop;
 	clGetEventProfilingInfo(event,CL_PROFILING_COMMAND_START,sizeof(start),&start,NULL);
 	clGetEventProfilingInfo(event,CL_PROFILING_COMMAND_END,  sizeof(stop),&stop, NULL);
-	printf("queue %p, event %p here: %llu -> %llu (%llu)\n",cmd_queue,event,start,stop,stop-start);
 	clGetEventProfilingInfo(event,CL_PROFILING_COMMAND_QUEUED,sizeof(start),&start,NULL);
 	clGetEventProfilingInfo(event,CL_PROFILING_COMMAND_SUBMIT,  sizeof(stop),&stop, NULL);
-	printf("queue %p, event %p there: %llu -> %llu\n",cmd_queue,event,start,stop);
 
 	// Pass kernel exec time to calling function
 	*time_start = start;


### PR DESCRIPTION
**Bugfix**
A bug that could lead to pair interactions being omitted when multiple input ligands for the same docking had overlapping atoms has been fixed.

**Features**
This PR adds functionality to allow for docking with only a covalently bound ligand (aka a flexible residue, `-F`) present when no moving ligand (`-L`) is specified.

Additionally, flexible residues can now also be specified in a filelist with a `-` behind the pdbqt. If a flexible residue is to be specified with a moving ligand it has to directly precede the ligand.pdbqt line. Example filelists:

```
receptor.maps.fld
flexres.pdbqt-
ligand1.pdbqt
ligand2.pdbqt
ligand3.pdbqt
```

Also, the following will work:
```
receptor.maps.fld
covalent_lig1.pdbqt-
covalent_lig2.pdbqt-
covalent_lig3.pdbqt-
```

Furthermore, care has been taken that the dlg and xml outputs with only flexible side-chains (with no moving ligands) correclty estimate the free energy with the unbound energy set to zero (as there is no unbound ligand) and that the RMSD clustering uses the flexres atoms.

Please test extensively as changes to both the free energy and RMSD clustering calculations could create bad output easily ...