### PR TITLE
feat/Added CMakeLists.txt file to the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,15 @@
 cmake_minimum_required(VERSION 3.18)
 project(AutoDock-GPU CXX)
 
-add_definitions(-DVERSION="1.0.0")
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --abbrev=40 --dirty --tags --always
+    OUTPUT_VARIABLE GIT_REPO_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(${GIT_REPO_VERSION} STREQUAL "")
+  file(READ BASE_VERSION GIT_REPO_VERSION)
+  set(GIT_REPO_VERSION "${GIT_REPO_VERSION}-release")
+endif()
+add_definitions(-DVERSION=${GIT_REPO_VERSION})
+message(STATUS "AutoDock-GPU Version ${GIT_REPO_VERSION}")
 
 option(BUILD_OPENCL "Build AutoDock-GPU with OpenCL backend" ON)
 option(BUILD_CUDA "Build AutoDock-GPU with CUDA backend" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.18)
 project(AutoDock-GPU CXX)
 
+find_package(Git REQUIRED)
+
 execute_process(COMMAND ${GIT_EXECUTABLE} describe --abbrev=40 --dirty --tags --always
     OUTPUT_VARIABLE GIT_REPO_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,13 +71,13 @@ add_test(NAME test_ligand COMMAND
     -gfpop 0
     -lsmet sw
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-add_test(NAME test_astex COMMAND
-  ${CMAKE_CURRENT_BINARY_DIR}/adgpu
-	  -ffile ./input_tsri/search-set-astex/2bsm/protein.maps.fld
-	  -lfile ./input_tsri/search-set-astex/2bsm/flex-xray.pdbqt
-	  -nrun 10
-	  -psize 10
-	  -resnam test_astex
-	  -gfpop 1
-	  -lsmet sw
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+# add_test(NAME test_astex COMMAND
+#   ${CMAKE_CURRENT_BINARY_DIR}/adgpu
+# 	  -ffile ./input_tsri/search-set-astex/2bsm/protein.maps.fld
+# 	  -lfile ./input_tsri/search-set-astex/2bsm/flex-xray.pdbqt
+# 	  -nrun 10
+# 	  -psize 10
+# 	  -resnam test_astex
+# 	  -gfpop 1
+# 	  -lsmet sw
+#   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,3 +58,26 @@ elseif(BUILD_OPENCL)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   add_dependencies(adgpu stringify)
 endif()
+
+include(CTest)
+add_test(NAME test_ligand COMMAND
+  ${CMAKE_CURRENT_BINARY_DIR}/adgpu
+    -ffile ./input/3ce3/derived/3ce3_protein.maps.fld
+    -lfile ./input/3ce3/derived/3ce3_ligand.pdbqt
+    -nrun 100
+    -ngen 27000
+    -psize 150
+    -resnam test
+    -gfpop 0
+    -lsmet sw
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME test_astex COMMAND
+  ${CMAKE_CURRENT_BINARY_DIR}/adgpu
+	  -ffile ./input_tsri/search-set-astex/2bsm/protein.maps.fld
+	  -lfile ./input_tsri/search-set-astex/2bsm/flex-xray.pdbqt
+	  -nrun 10
+	  -psize 10
+	  -resnam test_astex
+	  -gfpop 1
+	  -lsmet sw
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.18)
+project(AutoDock-GPU CXX)
+
+add_definitions(-DVERSION="1.0.0")
+
+option(BUILD_OPENCL "Build AutoDock-GPU with OpenCL backend" ON)
+option(BUILD_CUDA "Build AutoDock-GPU with CUDA backend" OFF)
+
+include_directories(
+  host/inc
+  common)
+
+file(GLOB ADGPU_SRC host/src/*.cpp)
+
+if(BUILD_CUDA)
+  message(STATUS "Building with CUDA")
+  enable_language(CUDA)
+  include_directories(cuda)
+  include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+  file(COPY_FILE host/inc/performdocking.h.Cuda host/inc/performdocking.h)
+  file(COPY_FILE host/src/performdocking.cpp.Cuda host/src/performdocking.cpp)
+  list(APPEND ADGPU_SRC "cuda/kernels.cu" "host/src/performdocking.cpp")
+elseif(BUILD_OPENCL)
+  message(STATUS "Building with OpenCL")
+  find_package(OpenCL REQUIRED)
+  add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
+  file(GLOB ADGPU_SRC_OPENCL device/*.cl)
+  file(GLOB ADGPU_SRC_OPENCL_CPP wrapcl/src/*.cpp)
+  include_directories(${OpenCL_INCLUDE_DIRS} "device" "wrapcl/inc")
+  link_directories(${OpenCL_LIBRARY})
+  file(COPY_FILE host/inc/performdocking.h.OpenCL host/inc/performdocking.h)
+  file(COPY_FILE host/src/performdocking.cpp.OpenCL host/src/performdocking.cpp)
+  list(APPEND ADGPU_SRC ${ADGPU_SRC_OPENCL} ${ADGPU_SRC_OPENCL_CPP} "host/src/performdocking.cpp")
+else()
+  message(FATAL_ERROR "Please specify -DBUILD_OPENCL or -DBUILD_CUDA option when invoking CMake")
+endif()
+
+add_executable(adgpu ${ADGPU_SRC})
+if(BUILD_CUDA)
+  set_property(TARGET adgpu PROPERTY CUDA_STANDARD 17)
+elseif(BUILD_OPENCL)
+  target_link_libraries(adgpu
+    ${OpenCL_LIBRARY}
+    OpenCL::OpenCL)
+  add_custom_target(
+    stringify
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/stringify_ocl_krnls.sh
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  add_dependencies(adgpu stringify)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,25 @@
 cmake_minimum_required(VERSION 3.18)
+set (CMAKE_CXX_STANDARD 11)
 project(AutoDock-GPU CXX)
 
 find_package(Git REQUIRED)
+if(OVERLAP)
+  if(APPLE)
+    set(CMAKE_C_COMPILER clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang\$")
+      set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp")
+      set(OpenMP_C_LIB_NAMES "omp")
+      set(OpenMP_omp_LIBRARY omp)
+    endif()
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang\$")
+      set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp")
+      set(OpenMP_CXX_LIB_NAMES "omp")
+      set(OpenMP_omp_LIBRARY omp)
+    endif()
+  endif(APPLE)
+  find_package(OpenMP REQUIRED)
+endif()
 
 execute_process(COMMAND ${GIT_EXECUTABLE} describe --abbrev=40 --dirty --tags --always
     OUTPUT_VARIABLE GIT_REPO_VERSION
@@ -27,25 +45,55 @@ if(BUILD_CUDA)
   enable_language(CUDA)
   include_directories(cuda)
   include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
-  file(COPY_FILE host/inc/performdocking.h.Cuda host/inc/performdocking.h)
-  file(COPY_FILE host/src/performdocking.cpp.Cuda host/src/performdocking.cpp)
+  file(CREATE_LINK host/inc/performdocking.h.Cuda host/inc/performdocking.h COPY_ON_ERROR)
+  file(CREATE_LINK host/src/performdocking.cpp.Cuda host/src/performdocking.cpp COPY_ON_ERROR)
   list(APPEND ADGPU_SRC "cuda/kernels.cu" "host/src/performdocking.cpp")
 elseif(BUILD_OPENCL)
   message(STATUS "Building with OpenCL")
+  if(NUMWI EQUAL 1)
+    add_definitions(-DN1WI)
+  elseif(NUMWI EQUAL 2)
+    add_definitions(-DN2WI)
+  elseif(NUMWI EQUAL 4)
+    add_definitions(-DN4WI)
+  elseif(NUMWI EQUAL 8)
+    add_definitions(-DN8WI)
+  elseif(NUMWI EQUAL 16)
+    add_definitions(-DN16WI)
+  elseif(NUMWI EQUAL 32)
+    add_definitions(-DN32WI)
+  elseif(NUMWI EQUAL 64)
+    add_definitions(-DN64WI)
+  elseif(NUMWI EQUAL 128)
+    add_definitions(-DN128WI)
+  elseif(NUMWI EQUAL 256)
+    add_definitions(-DN256WI)
+  else()
+    add_definitions(-DN64WI)
+  endif()
   find_package(OpenCL REQUIRED)
   add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
+  add_definitions(-DGPU_DEVICE)
+  add_definitions(-DK1=gpu_calc_initpop -DK2=gpu_sum_evals -DK3=perform_LS -DK4=gpu_gen_and_eval_newpops -DK5=gradient_minSD -DK6=gradient_minFire -DK7=gradient_minAD)
+  add_definitions(-DKRNL_SOURCE=./device/calcenergy.cl -DKRNL_DIRECTORY=./device -DKCMN_DIRECTORY=./common)
   file(GLOB ADGPU_SRC_OPENCL device/*.cl)
   file(GLOB ADGPU_SRC_OPENCL_CPP wrapcl/src/*.cpp)
   include_directories(${OpenCL_INCLUDE_DIRS} "device" "wrapcl/inc")
   link_directories(${OpenCL_LIBRARY})
-  file(COPY_FILE host/inc/performdocking.h.OpenCL host/inc/performdocking.h)
-  file(COPY_FILE host/src/performdocking.cpp.OpenCL host/src/performdocking.cpp)
+  file(CREATE_LINK host/inc/performdocking.h.OpenCL host/inc/performdocking.h COPY_ON_ERROR)
+  file(CREATE_LINK host/src/performdocking.cpp.OpenCL host/src/performdocking.cpp COPY_ON_ERROR)
   list(APPEND ADGPU_SRC ${ADGPU_SRC_OPENCL} ${ADGPU_SRC_OPENCL_CPP} "host/src/performdocking.cpp")
 else()
   message(FATAL_ERROR "Please specify -DBUILD_OPENCL or -DBUILD_CUDA option when invoking CMake")
 endif()
 
 add_executable(adgpu ${ADGPU_SRC})
+
+if(OVERLAP)
+  add_definitions(-DUSE_PIPELINE)
+  target_link_libraries(adgpu OpenMP::OpenMP_CXX)
+endif()
+
 if(BUILD_CUDA)
   set_property(TARGET adgpu PROPERTY CUDA_STANDARD 17)
 elseif(BUILD_OPENCL)
@@ -71,13 +119,3 @@ add_test(NAME test_ligand COMMAND
     -gfpop 0
     -lsmet sw
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-# add_test(NAME test_astex COMMAND
-#   ${CMAKE_CURRENT_BINARY_DIR}/adgpu
-# 	  -ffile ./input_tsri/search-set-astex/2bsm/protein.maps.fld
-# 	  -lfile ./input_tsri/search-set-astex/2bsm/flex-xray.pdbqt
-# 	  -nrun 10
-# 	  -psize 10
-# 	  -resnam test_astex
-# 	  -gfpop 1
-# 	  -lsmet sw
-#   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(${GIT_REPO_VERSION} STREQUAL "")
   file(READ BASE_VERSION GIT_REPO_VERSION)
   set(GIT_REPO_VERSION "${GIT_REPO_VERSION}-release")
 endif()
-add_definitions(-DVERSION=${GIT_REPO_VERSION})
+add_definitions(-DVERSION="${GIT_REPO_VERSION}")
 message(STATUS "AutoDock-GPU Version ${GIT_REPO_VERSION}")
 
 option(BUILD_OPENCL "Build AutoDock-GPU with OpenCL backend" ON)


### PR DESCRIPTION
Solves #173. Should be merged before _PR_ https://github.com/ccsb-scripps/AutoDock-GPU/pull/176.

A `CMakeLists.txt` has been added to the project with the purpose of showing a way to go on with a _CMake_-enabled simplified build system.

A test could be run for checking out this file system by running the following commands shown below.
1. For **CUDA** builds:
```bash
cmake . -DBUILD_CUDA=1 -B../AutoDock-GPU-Build-CUDA
cmake --build ../AutoDock-GPU-Build-CUDA -j`nproc`
(cd ../AutoDock-GPU-Build-CUDA && make CTEST_OUTPUT_ON_FAILURE=1 test)
```
2. For **OpenCL** builds:
```bash
cmake . -DBUILD_OPENCL=1 -B../AutoDock-GPU-Build-OpenCL
cmake --build ../AutoDock-GPU-Build-OpenCL -j`nproc`
(cd ../AutoDock-GPU-Build-OpenCL && make CTEST_OUTPUT_ON_FAILURE=1 test)
```