### PR TITLE
Output interacition count for contact analysis even when no interaction was found

### DIFF
--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -1217,8 +1217,8 @@ void generate_output(
 					fprintf(fp_xml, "\t\t\t\t<contact_analysis_residue>%s</contact_analysis_residue>\n", residue.c_str());
 					fprintf(fp_xml, "\t\t\t\t<contact_analysis_resid>  %s</contact_analysis_resid>\n", res_id.c_str());
 					fprintf(fp_xml, "\t\t\t\t<contact_analysis_chain>  %s</contact_analysis_chain>\n", chain.c_str());
-					fprintf(fp_xml, "\t\t\t</contact_analysis>\n");
 				}
+				fprintf(fp_xml, "\t\t\t</contact_analysis>\n");
 			}
 			fprintf(fp_xml, "\t\t\t<free_NRG_binding>   %.2f</free_NRG_binding>\n", myresults[j].interE + myresults[j].interflexE + torsional_energy + (!mypars->free_roaming_ligand) * (myresults[j].intraE + myresults[j].intraflexE));
 			fprintf(fp_xml, "\t\t\t<final_intermol_NRG> %.2f</final_intermol_NRG>\n", myresults[j].interE + myresults[j].interflexE);

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -565,8 +565,8 @@ void ligand_calc_output(
 			for(unsigned int k=0; k<calc.analysis.size()-j-1; k++)
 				if(calc.analysis[k].type>calc.analysis[k+1].type) // percolate larger types numbers up
 					std::swap(calc.analysis[k], calc.analysis[k+1]);
+		fprintf(fp, "ANALYSIS: COUNT %lu\n", calc.analysis.size());
 		if(calc.analysis.size()>0){
-			fprintf(fp, "ANALYSIS: COUNT %lu\n", calc.analysis.size());
 			std::string types    = "TYPE    {";
 			std::string lig_id   = "LIGID   {";
 			std::string ligname  = "LIGNAME {";
@@ -804,8 +804,8 @@ void generate_output(
 			fprintf(fp, "Time taken for this run:   %.3lfs\n\n", docking_avg_runtime);
 
 			if(mypars->contact_analysis){
+				fprintf(fp, "ANALYSIS: COUNT %lu\n", myresults[i].analysis.size());
 				if(myresults[i].analysis.size()>0){
-					fprintf(fp, "ANALYSIS: COUNT %lu\n", myresults[i].analysis.size());
 					std::string types    = "TYPE    {";
 					std::string lig_id   = "LIGID   {";
 					std::string ligname  = "LIGNAME {";
@@ -1170,8 +1170,8 @@ void generate_output(
 			j = energy_order[u];
 			fprintf(fp_xml, "\t\t<run id=\"%d\">\n",(myresults [j]).run_number);
 			if(mypars->contact_analysis){
+				fprintf(fp_xml, "\t\t\t<contact_analysis count=\"%lu\">\n", myresults[j].analysis.size());
 				if(myresults[j].analysis.size()>0){
-					fprintf(fp_xml, "\t\t\t<contact_analysis count=\"%lu\">\n", myresults[j].analysis.size());
 					std::string types;
 					std::string lig_id;
 					std::string ligname;


### PR DESCRIPTION
This PR adds output to the dlg or xml output for the contact analysis for cases with zero interactions.

The previous behavior was to not output any "ANALYSIS:" lines to dlg or "<contact_analysis>" fields to xml files for poses with zero interactions. This included the output of the interaction count. The new behavior in this PR is for those cases to output `ANALYSIS: COUNT 0` to dlg and/or `<contact_analysis count="0">` to xml file poses with no interaction found during the contact analysis.

The change should only lead to a small amount of additional data and potentially helps analysis tools downstream to distinguish outputs with no contact analysis from ones with contact analysis but no hits.