### PR TITLE
Fix for potential buffer overflow in results processing

### DIFF
--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -502,7 +502,7 @@ int main(int argc, char* argv[])
 	if(n_files>1){
 		printf("Savings from multithreading: %.3f sec\n",(total_setup_time+total_processing_time+total_exec_time) - seconds_since(time_start));
 		if(!initial_pars.xml2dlg) // in xml2dlg mode, there's only "idle time" (aka overlapped processing)
-			printf("Idle time of execution thread: %.3f sec\n",seconds_since(time_start) - total_exec_time);
+			printf("Idle time of execution thread: %.3f sec\n",total_setup_time+total_processing_time);
 		if (get_profiles && filelist.used && !initial_pars.xml2dlg) // output profile with filelist name or dpf file name (depending on what is available)
 			profiler.write_profiles_to_file((filelist.filename!=NULL) ? filelist.filename : initial_pars.dpffile);
 	} else printf("Processing time: %.3f sec\n",total_processing_time);

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -1330,7 +1330,6 @@ int gen_new_pdbfile(
 // If the operation was successful, the function returns 0, if not, it returns 1.
 {
 	FILE* fp;
-	char tempstr [256];
 
 	fp = fopen(filename, "w");
 	if (fp == NULL)
@@ -1341,10 +1340,10 @@ int gen_new_pdbfile(
 
 	unsigned int line_count = 0;
 	unsigned int atom_cnt = 0;
+	char tempstr [32];
 	while (line_count < myligand->file_content.size())
 	{
-		strcpy(tempstr,myligand->file_content[line_count].c_str());
-		line_count++;
+		strncpy(tempstr,myligand->file_content[line_count].c_str(),32);
 		if ((strncmp("ATOM", tempstr, 4) == 0) || (strncmp("HETATM", tempstr, 6) == 0))
 		{
 			tempstr[30] = '\0';
@@ -1355,7 +1354,8 @@ int gen_new_pdbfile(
 			                                                                  myligand->atom_idxyzq[atom_cnt][4], // q
 			                                                                  myligand->atom_types[((int)myligand->atom_idxyzq[atom_cnt][0])]); // type
 			atom_cnt++;
-		} else fputs(tempstr, fp);
+		} else fputs(myligand->file_content[line_count].c_str(), fp);
+		line_count++;
 	}
 
 	fclose(fp);

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -683,7 +683,6 @@ void generate_output(
 	double sum_energy [1000];
 	double best_energy [1000];
 	int best_energy_runid [1000];
-	char tempstr [256];
 
 	double cluster_tolerance = mypars->rmsd_tolerance;
 
@@ -719,7 +718,6 @@ void generate_output(
 
 		std::string pdbqt_template;
 		std::vector<unsigned int> atom_data;
-		char lineout [264];
 		bool output_ref_calcs = mypars->reflig_en_required;
 		if(mypars->given_xrayligandfile){
 			// writing xray ligand pdbqt file
@@ -730,9 +728,8 @@ void generate_output(
 			unsigned int line_count = 0;
 			while (line_count < ligand_xray->ligand_line_count)
 			{
-				strcpy(tempstr,ligand_xray->file_content[line_count].c_str());
 				line_count++;
-				fprintf(fp, "XRAY-LIGAND-PDBQT: %s", tempstr);
+				fprintf(fp, "XRAY-LIGAND-PDBQT: %s", ligand_xray->file_content[line_count].c_str());
 			}
 			fprintf(fp, "\n\n");
 		}
@@ -741,16 +738,16 @@ void generate_output(
 		if(mypars->free_roaming_ligand){
 			fprintf(fp, "    INPUT LIGAND PDBQT FILE:\n    ________________________\n\n\n");
 			ligand_calc_output(fp, "INPUT-LIGAND-PDBQT: USER", tables, ligand_ref, mypars, mygrid, mypars->contact_analysis, output_ref_calcs);
+			char tempstr [32];
 			while (line_count < ligand_ref->ligand_line_count)
 			{
-				strcpy(tempstr,ligand_ref->file_content[line_count].c_str());
-				line_count++;
-				fprintf(fp, "INPUT-LIGAND-PDBQT: %s", tempstr);
+				strncpy(tempstr,ligand_ref->file_content[line_count].c_str(),32);
+				fprintf(fp, "INPUT-LIGAND-PDBQT: %s", ligand_ref->file_content[line_count].c_str());
 				if ((strncmp("ATOM", tempstr, 4) == 0) || (strncmp("HETATM", tempstr, 6) == 0))
 				{
 					tempstr[30] = '\0';
-					sprintf(lineout, "DOCKED: %s", tempstr);
-					pdbqt_template += lineout;
+					pdbqt_template += "DOCKED: ";
+					pdbqt_template += tempstr;
 					atom_data.push_back(pdbqt_template.length());
 				} else{
 					if (strncmp("ROOT", tempstr, 4) == 0)
@@ -758,9 +755,9 @@ void generate_output(
 						pdbqt_template += "DOCKED: USER                              x       y       z     vdW  Elec       q    Type\n";
 						pdbqt_template += "DOCKED: USER                           _______ _______ _______ _____ _____    ______ ____\n";
 					}
-					sprintf(lineout, "DOCKED: %s", tempstr);
-					pdbqt_template += lineout;
+					pdbqt_template += "DOCKED: " + ligand_ref->file_content[line_count];
 				}
+				line_count++;
 			}
 			fprintf(fp, "\n\n");
 		}
@@ -768,16 +765,16 @@ void generate_output(
 		if (mypars->flexresfile) {
 			if ( strlen(mypars->flexresfile)>0 ) {
 				fprintf(fp, "    INPUT FLEXRES PDBQT FILE:\n    ________________________\n\n\n");
+				char tempstr [32];
 				while (line_count < ligand_ref->file_content.size())
 				{
-					strcpy(tempstr,ligand_ref->file_content[line_count].c_str());
-					line_count++;
-					fprintf(fp, "INPUT-FLEXRES-PDBQT: %s", tempstr);
+					strncpy(tempstr,ligand_ref->file_content[line_count].c_str(),32);
+					fprintf(fp, "INPUT-FLEXRES-PDBQT: %s", ligand_ref->file_content[line_count].c_str());
 					if ((strncmp("ATOM", tempstr, 4) == 0) || (strncmp("HETATM", tempstr, 6) == 0))
 					{
 						tempstr[30] = '\0';
-						sprintf(lineout, "DOCKED: %s", tempstr);
-						pdbqt_template += lineout;
+						pdbqt_template += "DOCKED: ";
+						pdbqt_template += tempstr;
 						atom_data.push_back(pdbqt_template.length());
 					} else{
 						if (strncmp("ROOT", tempstr, 4) == 0)
@@ -785,9 +782,9 @@ void generate_output(
 							pdbqt_template += "DOCKED: USER                              x       y       z     vdW  Elec       q    Type\n";
 							pdbqt_template += "DOCKED: USER                           _______ _______ _______ _____ _____    ______ ____\n";
 						}
-						sprintf(lineout, "DOCKED: %s", tempstr);
-						pdbqt_template += lineout;
+						pdbqt_template += "DOCKED: " + ligand_ref->file_content[line_count];
 					}
+					line_count++;
 				}
 				fprintf(fp, "\n\n");
 			}
@@ -930,6 +927,7 @@ void generate_output(
 			curr_model = pdbqt_template;
 			// inserting text from the end means prior text positions won't shift
 			// so there's less to keep track off ;-)
+			char lineout[51];
 			for(atom_cnt = ligand_ref->num_of_atoms; atom_cnt-->0;)
 			{
 				char* line = lineout;

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -728,8 +728,8 @@ void generate_output(
 			unsigned int line_count = 0;
 			while (line_count < ligand_xray->ligand_line_count)
 			{
-				line_count++;
 				fprintf(fp, "XRAY-LIGAND-PDBQT: %s", ligand_xray->file_content[line_count].c_str());
+				line_count++;
 			}
 			fprintf(fp, "\n\n");
 		}


### PR DESCRIPTION
This PR removes fixed sized strings to address one possible buffer overflow for pdbqt lines longer than 255 characters (see issue #209)