### PR TITLE
support turing and ampere for CUDA

### DIFF
--- a/Makefile.Cuda
+++ b/Makefile.Cuda
@@ -15,7 +15,7 @@ NVCC = nvcc
 CPP = g++
 UNAME := $(shell uname)
 
-TARGETS = 52 60 61 70
+TARGETS = 52 60 61 70 75 86
 CUDA_TARGETS=$(foreach target,$(TARGETS),-gencode arch=compute_$(target),code=sm_$(target))
 
 ifeq ($(DEVICE), CPU)


### PR DESCRIPTION
In turing and ampere device, `invalid device symbol` will be reported in:

```
123 static __constant__ GpuData cData;
124 static GpuData cpuData;
125 
126 void SetKernelsGpuData(GpuData* pData)
127 {
128     cudaError_t status;
129     status = cudaMemcpyToSymbol(cData, pData, sizeof(GpuData));                                                         
130    >> RTERROR(status, "SetKernelsGpuData copy to cData failed");
131     memcpy(&cpuData, pData, sizeof(GpuData));
132 }

```