### PR TITLE
Ensure later specified (i.e. on command line) modified pair parameters have priority

### DIFF
--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -739,7 +739,7 @@ pair_mod* is_mod_pair(
                             pair_mod* mod_atype_pairs
                      )
 {
-	for(int i=0; i<nr_mod_atype_pairs; i++) // need to make sure there isn't a modified pair
+	for(int i=nr_mod_atype_pairs; i-->0;) // find modified pair from last to first (so last specified ones, i.e. on command line, have priority)
 		if ( ((strcmp(mod_atype_pairs[i].A, A) == 0) && (strcmp(mod_atype_pairs[i].B, B) == 0)) ||
 		     ((strcmp(mod_atype_pairs[i].A, B) == 0) && (strcmp(mod_atype_pairs[i].B, A) == 0)))
 			return &mod_atype_pairs[i];


### PR DESCRIPTION
This is a fix to allow overriding of already specified modpair parameters (i.e. specified in read-in dpf but with new parameters on command line).
