### PR TITLE
Increased maximum number of runs to 8192

### DIFF
--- a/Makefile.OpenCL
+++ b/Makefile.OpenCL
@@ -16,6 +16,7 @@ LIB_OPENCL = -lOpenCL
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Darwin)
+CPP = clang++
 # In case ScoreP (for profiling/tracing) is used,
 # need to link to a *.dylib for instrumentation
 ifneq (,$(findstring scorep,$(CPP)))

--- a/common/defines.h
+++ b/common/defines.h
@@ -87,7 +87,7 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 #define MAX_INTRAE_CONTRIBUTORS    (MAX_NUM_OF_ATOMS * MAX_NUM_OF_ATOMS)
 #define MAX_NUM_OF_ROTATIONS       (MAX_NUM_OF_ATOMS * MAX_NUM_OF_ROTBONDS)
 #define MAX_POPSIZE                2048
-#define MAX_NUM_OF_RUNS            1000
+#define MAX_NUM_OF_RUNS            8192
 #define MAX_NUM_GRIDPOINTS         256
 
 // Must be larger than or equal to MAX_NUM_OF_ROTBONDS+6

--- a/host/inc/autostop.hpp
+++ b/host/inc/autostop.hpp
@@ -162,7 +162,7 @@ class AutoStop{
 	inline void print_intro(unsigned long num_of_generations, unsigned long num_of_energy_evals)
 	{
 		para_printf("\nExecuting docking runs, stopping automatically after either reaching %.2f kcal/mol standard deviation of\nthe best molecules of the last 4 * %u generations, %lu generations, or %lu evaluations:\n\n",stopstd,as_frequency,num_of_generations,num_of_energy_evals);
-		para_printf("Generations |  Evaluations |     Threshold    |  Average energy of best 10%%  | Samples |    Best energy\n");
+		para_printf("Generations |  Evaluations |     Threshold    |  Average energy of best 10%%  | Samples | Best Inter + Intra\n");
 		para_printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
 	}
 
@@ -221,7 +221,7 @@ class AutoStop{
 	inline void output_final_stddev(int generation_cnt, const float* energies, unsigned long total_evals){
 		if (autostopped){
 			para_printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
-			para_printf("\n%43s evaluation after reaching\n%40.2f +/-%8.2f kcal/mol combined.\n%34i samples, best energy %8.2f kcal/mol.\n","Finished",average(&average_sd2_N[0]),stddev(&average_sd2_N[0]),(unsigned int)average_sd2_N[2],overall_best_energy);
+			para_printf("\n%43s evaluation after reaching\n%40.2f +/-%8.2f kcal/mol combined.\n%31i samples, best inter + intra %8.2f kcal/mol.\n","Finished",average(&average_sd2_N[0]),stddev(&average_sd2_N[0]),(unsigned int)average_sd2_N[2],overall_best_energy);
 		} else {
 			// Stopped without autostop; output stddev statistics regardless
 
@@ -230,7 +230,7 @@ class AutoStop{
 
 			para_printf("%11u | %12lu |%8.2f kcal/mol |%8.2f +/-%8.2f kcal/mol |%8i |%8.2f kcal/mol\n",generation_cnt,total_evals/num_of_runs,threshold,curr_avg,curr_std,bestN,overall_best_energy);
 			para_printf("------------+--------------+------------------+------------------------------+---------+-------------------\n");
-			para_printf("\n%43s evaluation after reaching\n%33lu evaluations. Best energy %8.2f kcal/mol.\n","Finished",total_evals/num_of_runs,overall_best_energy);
+			para_printf("\n%43s evaluation after reaching\n%30lu evaluations. Best inter + intra %8.2f kcal/mol.\n","Finished",total_evals/num_of_runs,overall_best_energy);
 		}
 		fflush(stdout);
 	}

--- a/host/inc/getparameters.h
+++ b/host/inc/getparameters.h
@@ -213,7 +213,8 @@ int get_commandpars(
                           char**,
                           double*,
                           Dockpars*,
-                    const bool late_call = true
+                    const bool late_call = true,
+                    const int batch_nr = -1
                    );
 
 std::vector<ReceptorAtom> read_receptor_atoms(

--- a/host/inc/miscellaneous.h
+++ b/host/inc/miscellaneous.h
@@ -98,7 +98,11 @@ void vec_point2line(const double [], const double [], const double [], double []
 
 void rotate(double [], const double [], const double [], const double*, int);
 
+bool is_dirname(const char* filename);
+
 bool has_absolute_path(const char* filename);
+
+std::string get_base_filename(const char* filename);
 
 std::string get_filepath(const char* filename);
 

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -236,7 +236,7 @@ int main(int argc, char* argv[])
 	}
 #endif
 	// Set up run profiles for timing
-	bool get_profiles = true; // hard-coded switch to use ALS's job profiler
+	bool get_profiles = ((filelist.filename!=NULL) || (initial_pars.dpffile!=NULL)); // hard-coded switch to use ALS's job profiler
 	Profiler profiler;
 	for (int i=0;i<n_files;i++){
 		profiler.p.push_back(Profile(i));

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -410,6 +410,16 @@ int main(int argc, char* argv[])
 						para_printf("    Ligand file: %s\n", mypars.ligandfile); fflush(stdout);
 					if(mypars.flexresfile)
 						para_printf("    Flexible residue: %s\n", mypars.flexresfile);
+					if(mypars.output_dlg || mypars.output_xml){
+						para_printf("    Output file: %s", mypars.resname);
+						if(mypars.output_dlg){
+							para_printf(".dlg");
+							if(mypars.output_xml) para_printf(" (+ xml)");
+						} else{
+							if(mypars.output_xml) para_printf(".xml");
+						}
+						para_printf("\n");
+					}
 					fflush(stdout);
 				} else para_printf("\n");
 				// End idling timer, start exec timer

--- a/host/src/miscellaneous.cpp
+++ b/host/src/miscellaneous.cpp
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 
+#include <sys/stat.h>
+
 #include "miscellaneous.h"
 
 float map2float(const char* c)
@@ -257,6 +259,15 @@ void rotate(double point [], const double movvec [], const double normvec [], co
 		        point [0], point [1], point [2]);
 }
 
+bool is_dirname(const char* filename)
+{
+	if((filename[strlen(filename)-1] == '/') ||
+	   (filename[strlen(filename)-1] == '\\')) return true;
+	struct stat res_stat;
+	int res_int = stat(filename, &res_stat);
+	return (res_stat.st_mode & S_IFDIR);
+}
+
 bool has_absolute_path(const char* filename)
 {
 	#ifndef _WIN32
@@ -269,19 +280,24 @@ bool has_absolute_path(const char* filename)
 	#endif
 }
 
+std::string get_base_filename(const char* filename)
+{
+	std::string result = filename;
+	std::size_t path   = result.find_last_of("/\\");
+	if(path == std::string::npos) path = 0; else path++;
+	result = result.substr(path);
+	return result.substr(0, result.find_last_of("."));
+}
+
 std::string get_filepath(const char* filename)
 {
-	#ifndef _WIN32
-	char* ts1 = strdup(filename);
-	std::string result = dirname(ts1);
-	free(ts1);
-	return result;
-	#else
-	char drive_tmp[_MAX_DRIVE];
-	char path_tmp[_MAX_DIR];
-	_splitpath(filename, drive_tmp, path_tmp, NULL, NULL);
-	return drive_tmp + path_tmp;
-	#endif
+	std::string result = filename;
+	std::size_t path   = result.find_last_of("/\\");
+	if(path == std::string::npos){
+		if(is_dirname(filename)) return filename;
+		return ".";
+	}
+	return result.substr(0, path);
 }
 
 #if 0

--- a/host/src/performdocking.cpp.Cuda
+++ b/host/src/performdocking.cpp.Cuda
@@ -185,29 +185,6 @@ void setup_gpu_for_docking(
 		status = cudaMalloc((void**)&(tData.pMem_fgrids), cData.preallocated_gridsize*sizeof(float));
 		RTERROR(status, "pMem_fgrids: failed to allocate GPU memory.\n");
 	}
-	size_t size_populations = MAX_NUM_OF_RUNS * MAX_POPSIZE * GENOTYPE_LENGTH_IN_GLOBMEM*sizeof(float);
-	status = cudaMalloc((void**)&(tData.pMem_conformations1), size_populations);
-	RTERROR(status, "pMem_conformations1: failed to allocate GPU memory.\n");
-	status = cudaMalloc((void**)&(tData.pMem_conformations2), size_populations);
-	RTERROR(status, "pMem_conformations2: failed to allocate GPU memory.\n");
-	size_t size_energies = MAX_POPSIZE * MAX_NUM_OF_RUNS * sizeof(float);
-	status = cudaMalloc((void**)&(tData.pMem_energies1), size_energies);
-	RTERROR(status, "pMem_energies1: failed to allocate GPU memory.\n");
-	status = cudaMalloc((void**)&(tData.pMem_energies2), size_energies);
-	RTERROR(status, "pMem_energies2: failed to allocate GPU memory.\n");  
-	status = cudaMalloc((void**)&(tData.pMem_evals_of_new_entities), MAX_POPSIZE*MAX_NUM_OF_RUNS*sizeof(int));
-	RTERROR(status, "pMem_evals_of_new_Entities: failed to allocate GPU memory.\n");
-	size_t size_evals_of_runs = MAX_NUM_OF_RUNS*sizeof(int);
-#if defined (MAPPED_COPY)
-	status = cudaMallocManaged((void**)&(tData.pMem_gpu_evals_of_runs), size_evals_of_runs, cudaMemAttachGlobal);
-#else
-	status = cudaMalloc((void**)&(tData.pMem_gpu_evals_of_runs), size_evals_of_runs);
-#endif
-	RTERROR(status, "pMem_gpu_evals_of_runs: failed to allocate GPU memory.\n");
-	size_t blocksPerGridForEachEntity = MAX_POPSIZE * MAX_NUM_OF_RUNS;
-	size_t size_prng_seeds = blocksPerGridForEachEntity * NUM_OF_THREADS_PER_BLOCK * sizeof(unsigned int);
-	status = cudaMalloc((void**)&(tData.pMem_prng_states), size_prng_seeds);
-	RTERROR(status, "pMem_prng_states: failed to allocate GPU memory.\n");
 }
 void finish_gpu_from_docking(
                              GpuData& cData,
@@ -241,20 +218,6 @@ void finish_gpu_from_docking(
 		status = cudaFree(tData.pMem_fgrids);
 		RTERROR(status, "cudaFree: error freeing pMem_fgrids");
 	}
-	status = cudaFree(tData.pMem_conformations1);
-	RTERROR(status, "cudaFree: error freeing pMem_conformations1");
-	status = cudaFree(tData.pMem_conformations2);
-	RTERROR(status, "cudaFree: error freeing pMem_conformations2");
-	status = cudaFree(tData.pMem_energies1);
-	RTERROR(status, "cudaFree: error freeing pMem_energies1");
-	status = cudaFree(tData.pMem_energies2);
-	RTERROR(status, "cudaFree: error freeing pMem_energies2");
-	status = cudaFree(tData.pMem_evals_of_new_entities);
-	RTERROR(status, "cudaFree: error freeing pMem_evals_of_new_entities");
-	status = cudaFree(tData.pMem_gpu_evals_of_runs);
-	RTERROR(status, "cudaFree: error freeing pMem_gpu_evals_of_runs");
-	status = cudaFree(tData.pMem_prng_states);
-	RTERROR(status, "cudaFree: error freeing pMem_prng_states");
 	free(tData.device_name);
 }
 
@@ -357,6 +320,26 @@ parameters argc and argv:
 	size_evals_of_runs = mypars->num_of_runs*sizeof(int);
 	sim_state.cpu_evals_of_runs.resize(size_evals_of_runs);
 	memset(sim_state.cpu_evals_of_runs.data(), 0, size_evals_of_runs);
+	
+	// allocating memory blocks for GPU
+	status = cudaMalloc((void**)&(tData.pMem_conformations1), size_populations);
+	RTERROR(status, "pMem_conformations1: failed to allocate GPU memory.\n");
+	status = cudaMalloc((void**)&(tData.pMem_conformations2), size_populations);
+	RTERROR(status, "pMem_conformations2: failed to allocate GPU memory.\n");
+	status = cudaMalloc((void**)&(tData.pMem_energies1), size_energies);
+	RTERROR(status, "pMem_energies1: failed to allocate GPU memory.\n");
+	status = cudaMalloc((void**)&(tData.pMem_energies2), size_energies);
+	RTERROR(status, "pMem_energies2: failed to allocate GPU memory.\n");  
+	status = cudaMalloc((void**)&(tData.pMem_evals_of_new_entities), MAX_POPSIZE*MAX_NUM_OF_RUNS*sizeof(int));
+	RTERROR(status, "pMem_evals_of_new_Entities: failed to allocate GPU memory.\n");
+#if defined (MAPPED_COPY)
+	status = cudaMallocManaged((void**)&(tData.pMem_gpu_evals_of_runs), size_evals_of_runs, cudaMemAttachGlobal);
+#else
+	status = cudaMalloc((void**)&(tData.pMem_gpu_evals_of_runs), size_evals_of_runs);
+#endif
+	RTERROR(status, "pMem_gpu_evals_of_runs: failed to allocate GPU memory.\n");
+	status = cudaMalloc((void**)&(tData.pMem_prng_states), size_prng_seeds);
+	RTERROR(status, "pMem_prng_states: failed to allocate GPU memory.\n");
 
 	// preparing the constant data fields for the GPU
 	kernelconstant_interintra*	KerConst_interintra = new kernelconstant_interintra;
@@ -892,6 +875,21 @@ parameters argc and argv:
 	sim_state.total_evals = total_evals;
 
 	free(cpu_prng_seeds);
+
+	status = cudaFree(tData.pMem_conformations1);
+	RTERROR(status, "cudaFree: error freeing pMem_conformations1");
+	status = cudaFree(tData.pMem_conformations2);
+	RTERROR(status, "cudaFree: error freeing pMem_conformations2");
+	status = cudaFree(tData.pMem_energies1);
+	RTERROR(status, "cudaFree: error freeing pMem_energies1");
+	status = cudaFree(tData.pMem_energies2);
+	RTERROR(status, "cudaFree: error freeing pMem_energies2");
+	status = cudaFree(tData.pMem_evals_of_new_entities);
+	RTERROR(status, "cudaFree: error freeing pMem_evals_of_new_entities");
+	status = cudaFree(tData.pMem_gpu_evals_of_runs);
+	RTERROR(status, "cudaFree: error freeing pMem_gpu_evals_of_runs");
+	status = cudaFree(tData.pMem_prng_states);
+	RTERROR(status, "cudaFree: error freeing pMem_prng_states");
 
 	delete KerConst_interintra;
 	delete KerConst_intracontrib;

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -26,7 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
-#include <sys/stat.h>
 
 #include "filelist.hpp"
 #include "processgrid.h"
@@ -345,42 +344,8 @@ int setup(
 	//------------------------------------------------------------
 	// Capturing algorithm parameters (command line args)
 	//------------------------------------------------------------
-	char* orig_resname;
-	if(mypars->resname)
-		orig_resname = strdup(mypars->resname); // need to copy it since it might get free'd in the next line
-	else
-		orig_resname = strdup(""); // need an empty string for later if no resname has been specified
-
-	if(get_commandpars(&argc, argv, &(mygrid->spacing), mypars)<0)
+	if(get_commandpars(&argc, argv, &(mygrid->spacing), mypars, true, (filelist.nfiles>1)?i_file+1:0)<0)
 		return 1;
-
-	// command-line specified resname with more than one file
-	if (!mypars->xml2dlg){ // if the user specified an xml file, that's the one we want to use
-		if ((strcmp(orig_resname,mypars->resname)!=0) && (filelist.nfiles>1)){ // use resname as prefix
-			char* tmp = (char*)malloc(strlen(mypars->resname)+strlen(orig_resname)+1);
-			// take care of potential directory path
-			long long dir = strrchr(orig_resname,'/')-orig_resname+1;
-			if(dir>0){
-				strncpy(tmp, orig_resname, dir);
-				tmp[dir]='\0';
-				strcat(tmp, mypars->resname);
-				strcat(tmp, &orig_resname[dir]);
-			} else{
-				strcpy(tmp, mypars->resname);
-				strcat(tmp, orig_resname);
-			}
-			free(mypars->resname);
-			mypars->resname = tmp;
-		}
-	}
-	free(orig_resname);
-	
-	struct stat res_stat;
-	int res_int = stat(get_filepath(mypars->resname).c_str(), &res_stat);
-	if ((res_int != 0) || !(res_stat.st_mode & S_IFDIR)){
-		printf("\nError: Specified directory \"%s\" for output files (e.g. with `--resnam`) does not exist.\n",get_filepath(mypars->resname).c_str());
-		exit(11);
-	}
 
 	Gridinfo mydummygrid;
 	// if -lxrayfile provided, then read xray ligand data


### PR DESCRIPTION
This PR increases the maximum number of runs from 1000 to 8192. Besides simply changing the MAX_NUM_OF_RUNS define, in order for Cuda not to waste GPU memory it now, like OpenCL, allocates memory based on the actual settings of the number of runs and the population size instead of their max values.

This requires a little bit of additional testing on the Cuda side.