### PR TITLE
Generate residue specific best coordinate files

### DIFF
--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -2016,8 +2016,8 @@ int get_commandpars(
 				mypars->gen_finalpop = true;
 		}
 
-		// Argument: generate best.pdbqt
-		// If the value is zero, best.pdbqt file containing the coordinates of the best result found during all of the runs won't be generated, otherwise it will
+		// Argument: generate {resname}-best.pdbqt
+		// If the value is zero, {resname}-best.pdbqt files containing the coordinates of the best result found for each ligand during all of the runs won't be generated, otherwise they will
 		if (argcmp("gbest", argv [i]))
 		{
 			arg_recognized = 1;

--- a/host/src/processresult.cpp
+++ b/host/src/processresult.cpp
@@ -495,12 +495,17 @@ void make_resfiles(
 			}
 		}
 
-		// generating best.pdbqt (based on scoring function)
+		// generating {resname}-best.pdbqt (based on scoring function)
 		if (i == 0)
 			if (best_energy_of_all > accurate_interE + accurate_interflexE + accurate_intraE + accurate_intraflexE)
 			{
+				const char* suffix = "-best.pdbqt";
+				int len = strlen(mypars->resname) + strlen(suffix) + 1;
+				char* best_filename = (char*)malloc(len*sizeof(char));
+				strcpy(best_filename, mypars->resname);
+				strcat(best_filename, suffix);
 				best_energy_of_all = accurate_interE + accurate_interflexE + accurate_intraE + accurate_intraflexE;
-				if (mypars->gen_best) gen_new_pdbfile("best.pdbqt", ligand_ref);
+				if (mypars->gen_best) gen_new_pdbfile(best_filename, ligand_ref);
 			}
 
 		if (i < mypars->gen_pdbs) //if it is necessary, making new pdbqts for best entities


### PR DESCRIPTION
This way in batch jobs the best.pdbqt files won't overwrite each other, and it's more in line with how the xml output files are named.