### PR TITLE
Allow multiple xml inputs to serve as a docking starting point

### DIFF
--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -650,15 +650,15 @@ int initial_commandpars(
 		}
 		
 		// Argument: load initial data from xml file and reconstruct dlg, then finish
-		if (argcmp("xml2dlg", argv [i], 'X'))
+		if (argcmp("xml2dlg", argv [i], 'X') || argcmp("readxml", argv [i], 'c'))
 		{
 			if(mypars->xml_files>0){
-				printf("Error: Only one --xml2dlg (-X) argument is allowed.\n");
+				printf("Error: Only one --xml2dlg (-X) or --readxml (-c) argument is allowed.\n");
 				return 1;
 			}
 			mypars->load_xml = strdup(argv[i+1]);
 			read_more_xml_files = true;
-			mypars->xml2dlg = true;
+			mypars->xml2dlg = (argcmp("xml2dlg", argv [i], 'X'));
 			mypars->xml_files = 1;
 		}
 		
@@ -1749,11 +1749,11 @@ int get_commandpars(
 			}
 		}
 
-		// Argument: load initial population from xml file instead of generating one.
+		// Argument: load initial data from xml file to continue runs
 		if (argcmp("loadxml", argv [i], 'c'))
 		{
 			arg_recognized = 1;
-			mypars->load_xml = strdup(argv[i+1]);
+			i += mypars->xml_files-1; // skip ahead
 		}
 
 		// Argument: load initial data from xml file and reconstruct dlg, then finish

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -153,6 +153,9 @@ int main(int argc, char* argv[])
 		if (argcmp("xml2dlg", argv[i], 'X'))
 			i+=initial_pars.xml_files-1; // skip ahead in case there are multiple entries here
 		
+		if (argcmp("readxml", argv[i], 'c'))
+			i+=initial_pars.xml_files-1; // skip ahead in case there are multiple entries here
+		
 		if (argcmp("devnum", argv [i], 'D'))
 		{
 			if(stricmp(argv[i+1],"all")==0){

--- a/host/src/setup.cpp
+++ b/host/src/setup.cpp
@@ -87,6 +87,9 @@ int setup(
 		if (argcmp("xml2dlg", argv[i], 'X'))
 			i+=mypars->xml_files-1; // skip ahead in case there are multiple entries here
 
+		if (argcmp("readxml", argv[i], 'c'))
+			i+=mypars->xml_files-1; // skip ahead in case there are multiple entries here
+
 		// Argument: derivate atom types
 		if (argcmp("derivtype", argv [i], 'T'))
 		{


### PR DESCRIPTION
This PR allows to use an AD-GPU result xml to serve as input to start a docking.

Currently, this is not complete (no parsing of the command line parameters in the xml) so if different parameters (i.e. number of runs, etc.) were used they will need to be set up again but it should serve as a good starting point.