### PR TITLE
More expressive error messages and fix for grid map reading error non-persistence

### DIFF
--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -42,20 +42,21 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 // Struct containing all the important information coming from .gpf and .xyz files.
 typedef struct _Gridinfo
 {
-	std::string fld_name; // keep track of fld filename
-	std::string grid_file_path; // Added to store the full path of the grid file
-	std::string receptor_name;
-	std::string map_base_name;
-	int         size_xyz           [3];
-	double      spacing;
-	double      size_xyz_angstr    [3];
-	bool        fld_relative       = true;  // By default (and until further notice) map file names are relative to the fld file
-	int         num_of_map_atypes;
-	double      origo_real_xyz     [3];
-	unsigned int error_count       = 0;
-	std::vector<bool> map_present;
+	std::string  fld_name; // keep track of fld filename
+	std::string  grid_file_path; // Added to store the full path of the grid file
+	std::string  receptor_name;
+	std::string  map_base_name;
+	int          size_xyz           [3];
+	double       spacing;
+	double       size_xyz_angstr    [3];
+	bool         fld_relative        = true;  // By default (and until further notice) map file names are relative to the fld file
+	int          num_of_map_atypes;
+	double       origo_real_xyz     [3];
+	unsigned int error_count         = 0;
+	unsigned int e_and_d_present     = 0;
+	std::vector<bool>        map_present;
 	std::vector<std::string> grid_mapping;  // stores the atom types and associated map filenames from the fld file
-	std::vector<float> grids;
+	std::vector<float>       grids;
 } Gridinfo;
 
 struct Map

--- a/host/inc/processgrid.h
+++ b/host/inc/processgrid.h
@@ -49,10 +49,12 @@ typedef struct _Gridinfo
 	int         size_xyz           [3];
 	double      spacing;
 	double      size_xyz_angstr    [3];
-	bool        fld_relative       = true; // By default (and until further notice) map file names are relative to the fld file
+	bool        fld_relative       = true;  // By default (and until further notice) map file names are relative to the fld file
 	int         num_of_map_atypes;
 	double      origo_real_xyz     [3];
-	std::vector<std::string> grid_mapping; // stores the atom types and associated map filenames from the fld file
+	unsigned int error_count       = 0;
+	std::vector<bool> map_present;
+	std::vector<std::string> grid_mapping;  // stores the atom types and associated map filenames from the fld file
 	std::vector<float> grids;
 } Gridinfo;
 

--- a/host/src/getparameters.cpp
+++ b/host/src/getparameters.cpp
@@ -944,6 +944,8 @@ int get_filelist(
 					ligands.push_back(l.path().string());
 			// ligands may also contain receptor and/or flexres pdbqt - gets filtered out below
 			add_pdbqts = true;
+		} else if(std::filesystem::path(ligands[0]).extension() == ".pdbqt"){ // if parameter happens to be a single .pdbqt file, allow as ligand input
+			add_pdbqts = true;
 		} else filelist.filename = strdup(ligands[0].c_str());
 	}
 	if(add_pdbqts){

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -573,7 +573,7 @@ int main(int argc, char* argv[])
 	for(int i=0; i<error_grids.size(); i++){
 		mygrid = error_grids[i];
 		if(i==0) printf("\nWarning: The following grid maps could not be read (see above for more error messages):\n");
-		         printf("         * FLD file %s\n", mygrid->fld_name.c_str());
+		         printf("         * FLD file: %s\n", mygrid->fld_name.c_str());
 		for(int j=0; j<mygrid->map_present.size(); j++)
 			if(!mygrid->map_present[j])
 				printf("           - %s\n", mygrid->grid_mapping[j + mygrid->map_present.size()].c_str());

--- a/host/src/main.cpp
+++ b/host/src/main.cpp
@@ -344,7 +344,8 @@ int main(int argc, char* argv[])
 #endif
 			start_timer(setup_timer);
 			// Load files, read inputs, prepare arrays for docking stage
-			if (setup(mygrid, &mypars, myligand_init, myxrayligand, filelist, i_job, argc, argv) != 0) {
+			err[i_job] = setup(mygrid, &mypars, myligand_init, myxrayligand, filelist, i_job, argc, argv);
+			if (err[i_job] & 1) {
 				// If error encountered: Set error flag to 1; Add to count of finished jobs
 				// Keep in setup stage rather than moving to launch stage so a different job will be set up
 #ifdef USE_PIPELINE
@@ -362,7 +363,6 @@ int main(int argc, char* argv[])
 						fflush(stdout);
 					} else printf("\n");
 				}
-				err[i_job] = 1;
 				continue;
 			} else { // Successful setup
 #ifdef USE_PIPELINE
@@ -448,10 +448,10 @@ int main(int argc, char* argv[])
 				omp_unset_lock(&gpu_locks[dev_nr]);
 #endif
 				if (error_in_docking!=0){
-					// If error encountered: Set error flag to 1; Add to count of finished jobs
+					// If error encountered: Set error flag bit 3; Add to count of finished jobs
 					// Set back to setup stage rather than moving to processing stage so a different job will be set up
 					para_printf("\nError in docking_with_gpu, stopped Job #%d.\n",i_job+1);
-					err[i_job] = 1;
+					err[i_job] |= 4;
 					continue;
 				} else { // Successful run
 #ifdef USE_PIPELINE
@@ -547,18 +547,40 @@ int main(int argc, char* argv[])
 #endif
 	// Alert user to ligands that failed to complete
 	int n_errors=0;
+	Gridinfo*  mygrid = &initial_grid;
+	std::vector<Gridinfo*> error_grids;
 	for (int i=0; i<n_files; i++){
-		if (err[i]==1){
+		if((err[i] & 1) || (err[i] & 4)){ // job failed
 			if (filelist.used){
 				if (n_errors==0) printf("\nWarning: The following jobs were not successful:\n");
-				printf("         Job %d: %s\n", i, filelist.ligand_files[i].c_str());
+				printf("         Job #%d: %s", i+1, filelist.ligand_files[i].c_str());
+				if(err[i] & 2) printf(" (grid map error)");
+				if(err[i] & 4) printf(" (docking error)");
+				printf("\n");
 			} else {
-				printf("\nThe job was not successful.\n");
+				printf("\nThe job was not successful");
+				if(err[i] & 2) printf(" (grid map error)");
+				if(err[i] & 4) printf(" (docking error)");
+				printf(".\n");
 			}
 			n_errors++;
+		} else if(err[i] & 2){ // grid reading error but recoverable
+			if(filelist.used) mygrid = &filelist.mygrids[filelist.mypars[i].filelist_grid_idx];
+			error_grids.push_back(mygrid);
 		}
+
 	}
-	if (n_errors==0) printf("\nAll jobs ran without errors.\n");
+	for(int i=0; i<error_grids.size(); i++){
+		mygrid = error_grids[i];
+		if(i==0) printf("\nWarning: The following grid maps could not be read (see above for more error messages):\n");
+		         printf("         * FLD file %s\n", mygrid->fld_name.c_str());
+		for(int j=0; j<mygrid->map_present.size(); j++)
+			if(!mygrid->map_present[j])
+				printf("           - %s\n", mygrid->grid_mapping[j + mygrid->map_present.size()].c_str());
+	}
+	if (n_errors==0){
+		printf("\nAll jobs (%d) ran without errors.\n", n_files);
+	} else if(filelist.used) printf("\n%d jobs ran without errors, %d failed.\n",n_files-n_errors,n_errors);
 	fflush(stdout);
 
 	return 0;

--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -207,10 +207,13 @@ int get_gridvalues(Gridinfo* mygrid)
 	unsigned int g1 = mygrid->size_xyz[0];
 	unsigned int g2 = g1*mygrid->size_xyz[1];
 
-	mygrid->error_count = 0;
+	mygrid->error_count         = 0;
+	mygrid->e_and_d_present     = 0;
+	unsigned int e_or_d_failure = 0;
 	for (t=0; t < mygrid->grid_mapping.size()/2; t++)
 	{
 		bool map_reading_failure = false;
+		bool e_or_d = (mygrid->grid_mapping[t][0]=='e') || (mygrid->grid_mapping[t][0]=='d');
 		ti = t + mygrid->grid_mapping.size()/2;
 		if(mygrid->fld_relative){ // this is always true (unless changed)
 			fn=mygrid->grid_file_path;
@@ -223,8 +226,8 @@ int get_gridvalues(Gridinfo* mygrid)
 		{
 			fp.clear();
 			printf("Error: Can't open grid map %s specified in fld file.\n", fn.c_str());
-			printf("       Continuing in case ligands don't use it.\n");
 			map_reading_failure = true;
+			e_or_d_failure += e_or_d;
 			mygrid->error_count++;
 			continue;
 		}
@@ -235,6 +238,7 @@ int get_gridvalues(Gridinfo* mygrid)
 				printf("Error: Failed reading preamble of grid map %s: ", fn.c_str());
 				if(fp.eof()) printf("file too small.\n"); else printf("I/O error\n");
 				map_reading_failure = true;
+				e_or_d_failure += e_or_d;
 				mygrid->error_count++;
 				break;
 			}
@@ -251,6 +255,7 @@ int get_gridvalues(Gridinfo* mygrid)
 						printf("Error: Failed reading grid map data points from %s: ", fn.c_str());
 						if(fp.eof()) printf("file too small.\n"); else printf("I/O error\n");
 						map_reading_failure = true;
+						e_or_d_failure += e_or_d;
 						goto grid_reading_finish;
 					}
 					*mypoi = map2float(line.c_str());
@@ -265,6 +270,7 @@ grid_reading_finish:
 		mygrid->map_present[t]  = !map_reading_failure;
 		mygrid->error_count    += map_reading_failure;
 	}
+	mygrid->e_and_d_present = (e_or_d_failure > 2 ) ? 0 : 2 - e_or_d_failure;
 	return mygrid->error_count;
 }
 

--- a/host/src/processgrid.cpp
+++ b/host/src/processgrid.cpp
@@ -191,11 +191,14 @@ int get_gridvalues(Gridinfo* mygrid)
 // If there are any errors, it returns 1, otherwise
 // the return value is 0.
 {
-	if(mygrid->grids.size()>0) return 0; // we already read the grid maps
+	if(mygrid->grids.size()>0) return 0; // we already read the grid maps, even if some failed (0 to make the errors show up once for reading thread)
 	mygrid->grids.resize(2*mygrid->grid_mapping.size()*
 	                      (mygrid->size_xyz[0])*
 	                      (mygrid->size_xyz[1])*
 	                      (mygrid->size_xyz[2]));
+	mygrid->map_present.resize(mygrid->grid_mapping.size()/2);
+	std::fill(mygrid->map_present.begin(), mygrid->map_present.end(), false);
+	
 	int t, ti, x, y, z;
 	std::ifstream fp;
 	std::string fn, line;
@@ -204,8 +207,10 @@ int get_gridvalues(Gridinfo* mygrid)
 	unsigned int g1 = mygrid->size_xyz[0];
 	unsigned int g2 = g1*mygrid->size_xyz[1];
 
+	mygrid->error_count = 0;
 	for (t=0; t < mygrid->grid_mapping.size()/2; t++)
 	{
+		bool map_reading_failure = false;
 		ti = t + mygrid->grid_mapping.size()/2;
 		if(mygrid->fld_relative){ // this is always true (unless changed)
 			fn=mygrid->grid_file_path;
@@ -216,8 +221,12 @@ int get_gridvalues(Gridinfo* mygrid)
 		}
 		if (fp.fail())
 		{
-			printf("Error: Can't open grid map %s.\n", fn.c_str());
-			return 1;
+			fp.clear();
+			printf("Error: Can't open grid map %s specified in fld file.\n", fn.c_str());
+			printf("       Continuing in case ligands don't use it.\n");
+			map_reading_failure = true;
+			mygrid->error_count++;
+			continue;
 		}
 
 		// seeking to first data
@@ -225,10 +234,13 @@ int get_gridvalues(Gridinfo* mygrid)
 			if(!std::getline(fp, line)){
 				printf("Error: Failed reading preamble of grid map %s: ", fn.c_str());
 				if(fp.eof()) printf("file too small.\n"); else printf("I/O error\n");
-				return 1;
+				map_reading_failure = true;
+				mygrid->error_count++;
+				break;
 			}
 		}
 		while (line.find("CENTER") != 0);
+		if(map_reading_failure) continue;
 
 		// reading values
 		for (z=0; z < mygrid->size_xyz[2]; z++)
@@ -238,7 +250,8 @@ int get_gridvalues(Gridinfo* mygrid)
 					if(!std::getline(fp, line)){ // sscanf(line.c_str(), "%f", mypoi);
 						printf("Error: Failed reading grid map data points from %s: ", fn.c_str());
 						if(fp.eof()) printf("file too small.\n"); else printf("I/O error\n");
-						return 1;
+						map_reading_failure = true;
+						goto grid_reading_finish;
 					}
 					*mypoi = map2float(line.c_str());
 					// fill in duplicate data for linearized memory access in kernel
@@ -247,8 +260,11 @@ int get_gridvalues(Gridinfo* mygrid)
 					if(y>0 && z>0) *(mypoi-4*(g2+g1)+3) = *mypoi;
 					mypoi+=4;
 				}
+grid_reading_finish:
 		fp.close();
+		mygrid->map_present[t]  = !map_reading_failure;
+		mygrid->error_count    += map_reading_failure;
 	}
-	return 0;
+	return mygrid->error_count;
 }
 

--- a/host/src/processligand.cpp
+++ b/host/src/processligand.cpp
@@ -238,12 +238,16 @@ int set_liganddata_typeid(
 				return 1;
 			}
 		}
+		if(!mygrid->map_present[myligand->atom_map_to_fgrids[atom_id]]){
+			printf("Error: Grid map reading failed for ligand atom type %s (see error message earlier).\n", typeof_new_atom);
+			return 3;
+		}
 		return 0;
 	}
 	else // if typeof_new_atom hasn't been found
 	{
 		printf("Error: No grid map for ligand atom type %s.\n", typeof_new_atom);
-		return 1;
+		return 3;
 	}
 }
 
@@ -1189,8 +1193,8 @@ int parse_liganddata(
 				// moved by the three spaces above
 				range_trim_to_char(line, 80, 83, tempstr); // reading atom type
 				sscanf(&line.c_str()[73], "%lf", &(myligand->atom_idxyzq [atom_counter][4])); // reading charge (there's a space behind it)
-				if (set_liganddata_typeid(myligand, mygrid, atom_counter, tempstr) != 0) // the function sets the type index
-					return 1;
+				int err_status = set_liganddata_typeid(myligand, mygrid, atom_counter, tempstr); // the function sets the type index
+				if (err_status != 0) return err_status;
 				if(tempstr[0]=='G'){ // G-type are ignored for inter calc unless there is a map specified (checked above)
 					if(strcmp(myligand->atom_types[(int)myligand->atom_idxyzq[atom_counter][0]],myligand->base_atom_types[(int)myligand->atom_idxyzq[atom_counter][0]])==0) // derived Gx type does not exists
 						myligand->ignore_inter[atom_counter] = true;


### PR DESCRIPTION
This PR fixes a recently discovered bug (thank you @maylinnp) that batch jobs would continue even though parts of the grid map had reading errors.

Additionally, I added more expressive error messages at the end of the run summary including which grid maps failed if any and if a job failed due to a grid map error or docking error.

This PR should not affect docking.