### PR TITLE
PDBQT connectivity improvement

### DIFF
--- a/host/inc/processligand.h
+++ b/host/inc/processligand.h
@@ -32,9 +32,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 // expand the allowed bond length ranges by the BOND_LENGTH_TOLERANCE
 #define BOND_LENGTH_TOLERANCE 0.1
+#define BOND_LENGTH_TOLERANCE_FACTOR 1.1
 #define set_minmax( a1, a2, min, max)  \
-    mindist[(a1)][(a2)] = (min)-BOND_LENGTH_TOLERANCE;\
-    maxdist[(a1)][(a2)] = (max)+BOND_LENGTH_TOLERANCE;\
+    mindist[(a1)][(a2)] = ((min)-BOND_LENGTH_TOLERANCE)/BOND_LENGTH_TOLERANCE_FACTOR;\
+    maxdist[(a1)][(a2)] = ((max)+BOND_LENGTH_TOLERANCE)*BOND_LENGTH_TOLERANCE_FACTOR;\
     if((a1) != (a2)){\
         mindist[(a2)][(a1)] = mindist[(a1)][(a2)];\
         maxdist[(a2)][(a1)] = maxdist[(a1)][(a2)];\


### PR DESCRIPTION
This PR adds a bond length tolerance factor (set at 1.1) to increase robustness of our pdbqt connectivity detection.

Connectivity is used in AD4/AD-GPU to exclude intramolecular pairs with bond distances up to 1-4 interactions. While a misdetection is usually not fatal to docking, it can lead to extra intramolecular pairs which in turn may affect docking results.

We've seen such misdetection in one of our E50 test ligands (1sq5) - so a full E50 test will be needed to verify this PR.